### PR TITLE
Nginx native fix

### DIFF
--- a/tests/conan_range_from_native_basic_test.json
+++ b/tests/conan_range_from_native_basic_test.json
@@ -39,7 +39,7 @@
         "scheme": "conan",
         "native_range": "~2.5"
       },
-      "expected_output": "vers:conan/>=2.5|<2.6-"
+      "expected_output": "vers:conan/>=2.5|<2.6"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -49,7 +49,7 @@
         "scheme": "conan",
         "native_range": "~2.5.1"
       },
-      "expected_output": "vers:conan/>=2.5.1|<2.6-"
+      "expected_output": "vers:conan/>=2.5.1|<2.6"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -59,7 +59,7 @@
         "scheme": "conan",
         "native_range": "~1"
       },
-      "expected_output": "vers:conan/>=1|<2-"
+      "expected_output": "vers:conan/>=1|<2"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -69,7 +69,7 @@
         "scheme": "conan",
         "native_range": "^1.2"
       },
-      "expected_output": "vers:conan/>=1.2|<2-"
+      "expected_output": "vers:conan/>=1.2|<2"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -79,7 +79,7 @@
         "scheme": "conan",
         "native_range": "^1.2.3"
       },
-      "expected_output": "vers:conan/>=1.2.3|<2-"
+      "expected_output": "vers:conan/>=1.2.3|<2"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -89,7 +89,7 @@
         "scheme": "conan",
         "native_range": "^0.1.2"
       },
-      "expected_output": "vers:conan/>=0.1.2|<0.2-"
+      "expected_output": "vers:conan/>=0.1.2|<0.2"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -139,7 +139,7 @@
         "scheme": "conan",
         "native_range": ">1 <2.0 || ^3.2 "
       },
-      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4-"
+      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -179,7 +179,7 @@
         "scheme": "conan",
         "native_range": ">1- <2.0 || ^3.2 "
       },
-      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4-"
+      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -189,7 +189,7 @@
         "scheme": "conan",
         "native_range": "^1.1.2-"
       },
-      "expected_output": "vers:conan/>=1.1.2|<2-"
+      "expected_output": "vers:conan/>=1.1.2|<2"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -199,7 +199,7 @@
         "scheme": "conan",
         "native_range": "~1.1.2-"
       },
-      "expected_output": "vers:conan/>=1.1.2|<1.2-"
+      "expected_output": "vers:conan/>=1.1.2|<1.2"
     }
   ]
 }

--- a/tests/conan_range_from_native_basic_test.json
+++ b/tests/conan_range_from_native_basic_test.json
@@ -39,7 +39,7 @@
         "scheme": "conan",
         "native_range": "~2.5"
       },
-      "expected_output": "vers:conan/>=2.5|<2.6"
+      "expected_output": "vers:conan/>=2.5|<2.6-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -49,7 +49,7 @@
         "scheme": "conan",
         "native_range": "~2.5.1"
       },
-      "expected_output": "vers:conan/>=2.5.1|<2.6"
+      "expected_output": "vers:conan/>=2.5.1|<2.6-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -59,7 +59,7 @@
         "scheme": "conan",
         "native_range": "~1"
       },
-      "expected_output": "vers:conan/>=1|<2"
+      "expected_output": "vers:conan/>=1|<2-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -69,7 +69,7 @@
         "scheme": "conan",
         "native_range": "^1.2"
       },
-      "expected_output": "vers:conan/>=1.2|<2"
+      "expected_output": "vers:conan/>=1.2|<2-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -79,7 +79,7 @@
         "scheme": "conan",
         "native_range": "^1.2.3"
       },
-      "expected_output": "vers:conan/>=1.2.3|<2"
+      "expected_output": "vers:conan/>=1.2.3|<2-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -89,7 +89,7 @@
         "scheme": "conan",
         "native_range": "^0.1.2"
       },
-      "expected_output": "vers:conan/>=0.1.2|<0.2"
+      "expected_output": "vers:conan/>=0.1.2|<0.2-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -139,7 +139,7 @@
         "scheme": "conan",
         "native_range": ">1 <2.0 || ^3.2 "
       },
-      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4"
+      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -179,7 +179,7 @@
         "scheme": "conan",
         "native_range": ">1- <2.0 || ^3.2 "
       },
-      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4"
+      "expected_output": "vers:conan/>1|<2.0|>=3.2|<4-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -189,7 +189,7 @@
         "scheme": "conan",
         "native_range": "^1.1.2-"
       },
-      "expected_output": "vers:conan/>=1.1.2|<2"
+      "expected_output": "vers:conan/>=1.1.2|<2-"
     },
     {
       "description": "Construct VERS range from native Conan C/C++ range.",
@@ -199,7 +199,7 @@
         "scheme": "conan",
         "native_range": "~1.1.2-"
       },
-      "expected_output": "vers:conan/>=1.1.2|<1.2"
+      "expected_output": "vers:conan/>=1.1.2|<1.2-"
     }
   ]
 }

--- a/tests/nginx_range_from_native_test.json
+++ b/tests/nginx_range_from_native_test.json
@@ -40,46 +40,6 @@
         "scheme": "nginx"
       },
       "expected_output": "vers:nginx/>=1.4.1|<1.5.0|>=1.5.0"
-    },
-    {
-      "description": "Construct VERS range from native Nginx range.",
-      "test_group": "advanced",
-      "test_type": "from_native",
-      "input": {
-        "native_range": "0.8.40+",
-        "scheme": "nginx"
-      },
-      "expected_output": "vers:nginx/>=0.8.40|<0.9.0"
-    },
-    {
-      "description": "Construct VERS range from native Nginx range.",
-      "test_group": "advanced",
-      "test_type": "from_native",
-      "input": {
-        "native_range": "0.7.52-0.8.39",
-        "scheme": "nginx"
-      },
-      "expected_output": "vers:nginx/>=0.7.52|<=0.8.39"
-    },
-    {
-      "description": "Construct VERS range from native Nginx range.",
-      "test_group": "advanced",
-      "test_type": "from_native",
-      "input": {
-        "native_range": "0.9.10",
-        "scheme": "nginx"
-      },
-      "expected_output": "vers:nginx/0.9.10"
-    },
-    {
-      "description": "Construct VERS range from native Nginx range.",
-      "test_group": "advanced",
-      "test_type": "from_native",
-      "input": {
-        "native_range": "1.5.0+, 1.4.1+",
-        "scheme": "nginx"
-      },
-      "expected_output": "vers:nginx/>=1.4.1|<1.5.0|>=1.5.0"
     }
   ]
 }


### PR DESCRIPTION
The following duplicates were found (string + frequency) and removed
```
  0.7.52-0.8.39 (2)
  0.8.40+ (2)
  0.9.10 (2)
  1.5.0+, 1.4.1+ (2)