### PR TITLE
Fix typo in VERS spec from "=!" to "!="

### DIFF
--- a/VERSION-RANGE-SPEC.md
+++ b/VERSION-RANGE-SPEC.md
@@ -508,7 +508,7 @@ To check if a "tested version" is contained within a version range:
     finished.
 
   - If the "tested version" is equal to the any of the constraint
-    versions where the constraint comparator is "!=\" then the "tested
+    versions where the constraint comparator is "\!=" then the "tested
     version" is NOT in the range. Check is finished.
 
   - Split the constraint list in two sub lists:


### PR DESCRIPTION
This bug was originally reportd against VERSION-RANGE-SPEC.rst in the purl-spec repo