### PR TITLE
fix: typo in `npm_range_containment_test.json`

### DIFF
--- a/tests/npm_range_containment_test.json
+++ b/tests/npm_range_containment_test.json
@@ -6,7 +6,7 @@
       "test_group": "advanced",
       "test_type": "containment",
       "input": {
-        "vers": "vers:nginx/*",
+        "vers": "vers:npm/*",
         "version": "1.0.0"
       },
       "expected_output": true


### PR DESCRIPTION
In line with the filename, the type of the vers string should be `npm` here.

Resolves https://github.com/package-url/vers-spec/issues/55