### PR TITLE
fix: pypi_range_roundtrip_test.json schema compliance

### DIFF
--- a/tests/pypi_range_roundtrip_test.json
+++ b/tests/pypi_range_roundtrip_test.json
@@ -5,171 +5,133 @@
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.2"
-      },
+      "input": "vers:pypi/>0.0.2",
       "expected_output": "vers:pypi/>0.0.2"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/0.0.2|0.0.6|0.0.0|0.0.1|0.0.4|0.0.5|0.0.3"
-      },
+      "input": "vers:pypi/0.0.2|0.0.6|0.0.0|0.0.1|0.0.4|0.0.5|0.0.3",
       "expected_output": "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|0.0.4|0.0.5|0.0.6"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6"
-      },
+      "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3"
-      },
+      "input": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8"
-      },
+      "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.1"
-      },
+      "input": "vers:pypi/>0.0.1",
       "expected_output": "vers:pypi/>0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>=0.0.1"
-      },
+      "input": "vers:pypi/>=0.0.1",
       "expected_output": "vers:pypi/>=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/<0.0.1"
-      },
+      "input": "vers:pypi/<0.0.1",
       "expected_output": "vers:pypi/<0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/<=0.0.1"
-      },
+      "input": "vers:pypi/<=0.0.1",
       "expected_output": "vers:pypi/<=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/0.0.1"
-      },
+      "input": "vers:pypi/0.0.1",
       "expected_output": "vers:pypi/0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/!=0.0.1"
-      },
+      "input": "vers:pypi/!=0.0.1",
       "expected_output": "vers:pypi/!=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/*"
-      },
+      "input": "vers:pypi/*",
       "expected_output": "vers:pypi/*"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>0.0.1|<0.1"
-      },
+      "input": "vers:pypi/>0.0.1|<0.1",
       "expected_output": "vers:pypi/>0.0.1|<0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/>=0.0.1|<0.1"
-      },
+      "input": "vers:pypi/>=0.0.1|<0.1",
       "expected_output": "vers:pypi/>=0.0.1|<0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/<0.0.1|>0.1"
-      },
+      "input": "vers:pypi/<0.0.1|>0.1",
       "expected_output": "vers:pypi/<0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/<=0.0.1|>0.1"
-      },
+      "input": "vers:pypi/<=0.0.1|>0.1",
       "expected_output": "vers:pypi/<=0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/0.0.1|>0.1"
-      },
+      "input": "vers:pypi/0.0.1|>0.1",
       "expected_output": "vers:pypi/0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/!=0.0.1|>0.1"
-      },
+      "input": "vers:pypi/!=0.0.1|>0.1",
       "expected_output": "vers:pypi/!=0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
       "test_group": "advanced",
       "test_type": "roundtrip",
-      "input": {
-        "vers": "vers:pypi/0.0.2|0.0.6|>=0.0.0|0.0.1|0.0.4|0.0.5|0.0.3"
-      },
+      "input": "vers:pypi/0.0.2|0.0.6|>=0.0.0|0.0.1|0.0.4|0.0.5|0.0.3",
       "expected_output": "vers:pypi/>=0.0.0|0.0.1|0.0.2|0.0.3|0.0.4|0.0.5|0.0.6"
     }
   ]


### PR DESCRIPTION
As per the vers-test.schema-*.json, a `roundtrip` input property is required and has to be a string.

Currently, pypi_range_roundtrip_test.json contains the only set of roundtrip tests, and has input as a object with property `vers` of type string. This contradicts the schema.

This PR resolves this by removing the nested `vers` property. If the schema is actually incorrect here, I'm happy to modify the schema to fit the test file instead (would be done as part of #68)

