### PR TITLE
Datetime type: add missing tests and clarify spec

### DIFF
--- a/docs/specification/standard/specification.md
+++ b/docs/specification/standard/specification.md
@@ -155,8 +155,8 @@ RFC3339 but are non-canonical in VERS.
 **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
 shall be quoted using the URL quoting rules. This should be rare in practice.
 - Reserved URI characters that are allowed as data in the VERS path component
-for a given **type** do not need percent-encoding. For example, the colon ':'
-used inside RFC3339 'datetime' versions is data and shall remain unencoded.
+  for a given **type** do not need percent-encoding. For example, the colon ':'
+  used inside RFC3339 'datetime' versions is data and shall remain unencoded.
 - When percent-encoding is used in versions, it shall be valid as defined in RFC 3986, Section 2.1.
 
 The list of **constraints** strings for a range are like a set of

--- a/docs/specification/standard/specification.md
+++ b/docs/specification/standard/specification.md
@@ -147,10 +147,10 @@ impossible version ranges.
 - The VERS **scheme** and **type** are always lowercase as in
   'vers:npm'.
 - Versions are case-sensitive. A **type** may specify
-its own case sensitivity.
+  its own case sensitivity.
 - For the 'datetime' **type**, canonical VERS uses uppercase 'T' and 'Z' as
-specified by RFC3339 section 5.6. Lowercase 't' and 'z' are permitted by
-RFC3339 but are non-canonical in VERS.
+  specified by RFC3339 section 5.6. Lowercase 't' and 'z' are permitted by
+  RFC3339 but are non-canonical in VERS.
 - If a version in a **constraints** string contains **separator** or
 **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
 shall be quoted using the URL quoting rules. This should be rare in practice.

--- a/docs/specification/standard/specification.md
+++ b/docs/specification/standard/specification.md
@@ -152,8 +152,8 @@ impossible version ranges.
   specified by RFC3339 section 5.6. Lowercase 't' and 'z' are permitted by
   RFC3339 but are non-canonical in VERS.
 - If a version in a **constraints** string contains **separator** or
-**comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
-shall be quoted using the URL quoting rules. This should be rare in practice.
+  **comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
+  shall be quoted using the URL quoting rules. This should be rare in practice.
 - Reserved URI characters that are allowed as data in the VERS path component
   for a given **type** do not need percent-encoding. For example, the colon ':'
   used inside RFC3339 'datetime' versions is data and shall remain unencoded.

--- a/docs/specification/standard/specification.md
+++ b/docs/specification/standard/specification.md
@@ -148,11 +148,16 @@ impossible version ranges.
   'vers:npm'.
 - Versions are case-sensitive. A **type** may specify
 its own case sensitivity.
-- If a version in a **constraints** string contains any of these characters:
-  '>', '<', '=', '!', '*', '|', '%', these characters shall be
-  percent-encoded using URI percent-encoding rules.
-- Percent-encoding in versions shall be canonical. Tools shall report an error
-  for invalid or non-canonical percent-encoded sequences.
+- For the 'datetime' **type**, canonical VERS uses uppercase 'T' and 'Z' as
+specified by RFC3339 section 5.6. Lowercase 't' and 'z' are permitted by
+RFC3339 but are non-canonical in VERS.
+- If a version in a **constraints** string contains **separator** or
+**comparator** characters (i.e., '>', '<', '=', '!', '*', '|'), the version
+shall be quoted using the URL quoting rules. This should be rare in practice.
+- Reserved URI characters that are allowed as data in the VERS path component
+for a given **type** do not need percent-encoding. For example, the colon ':'
+used inside RFC3339 'datetime' versions is data and shall remain unencoded.
+- When percent-encoding is used in versions, it shall be valid as defined in RFC 3986, Section 2.1.
 
 The list of **constraints** strings for a range are like a set of
 signposts in the version timeline of a package. The separators do not mean

--- a/docs/types/vers-types.md
+++ b/docs/types/vers-types.md
@@ -52,7 +52,11 @@ cases:
   versions. 'vers:all/*' is the only valid VERS form for this **type**.
 - **datetime**: a generic VERS **type** that uses a timestamp for comparison.
   The timestamp must adhere to RFC3339, section 5.6. See
-  https://www.rfc-editor.org/rfc/rfc3339#section-5.6.
+  https://www.rfc-editor.org/rfc/rfc3339#section-5.6. In canonical VERS,
+  datetime values use an uppercase 'T' date/time separator and an uppercase
+  'Z' UTC designator. Lowercase 't' and 'z' are permitted by RFC3339, but are
+  non-canonical for VERS. The colon ':' characters used within the time and
+  UTC offset are part of the datetime version string and shall not be percent-encoded.
 - **generic**: a generic VERS **type** using a comparison algorithm which
   will be specified later, likely based on a split on any wholly alpha or
   wholly numeric segments and dealing with digit and string

--- a/tests/datetime_version_cmp_test.json
+++ b/tests/datetime_version_cmp_test.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://packageurl.org/schemas/vers-test.schema-0.1.json",
+  "tests": [
+    {
+      "description": "Identical RFC3339 timestamps are equal.",
+      "test_group": "base",
+      "test_type": "equality",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:00Z",
+          "2024-01-01T00:00:00Z"
+        ]
+      },
+      "expected_output": true
+    },
+    {
+      "description": "Different RFC3339 offsets representing the same instant are equal.",
+      "test_group": "base",
+      "test_type": "equality",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:00Z",
+          "2023-12-31T19:00:00-05:00"
+        ]
+      },
+      "expected_output": true
+    },
+    {
+      "description": "Fractional seconds do not change equality when they represent the same instant.",
+      "test_group": "base",
+      "test_type": "equality",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:00Z",
+          "2024-01-01T00:00:00.000Z"
+        ]
+      },
+      "expected_output": true
+    },
+    {
+      "description": "Earlier UTC timestamp sorts before a later UTC timestamp.",
+      "test_group": "base",
+      "test_type": "comparison",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:01Z",
+          "2024-01-01T00:00:00Z"
+        ]
+      },
+      "expected_output": [
+        "2024-01-01T00:00:00Z",
+        "2024-01-01T00:00:01Z"
+      ]
+    },
+    {
+      "description": "Ordering is based on the normalized instant, not lexical string order.",
+      "test_group": "base",
+      "test_type": "comparison",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:00+02:00",
+          "2023-12-31T23:00:00Z"
+        ]
+      },
+      "expected_output": [
+        "2024-01-01T00:00:00+02:00",
+        "2023-12-31T23:00:00Z"
+      ]
+    },
+    {
+      "description": "Equal wall-clock times with different offsets sort by their UTC instant.",
+      "test_group": "base",
+      "test_type": "comparison",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T12:00:00Z",
+          "2024-01-01T12:00:00-05:00",
+          "2024-01-01T12:00:00+02:00"
+        ]
+      },
+      "expected_output": [
+        "2024-01-01T12:00:00+02:00",
+        "2024-01-01T12:00:00Z",
+        "2024-01-01T12:00:00-05:00"
+      ]
+    },
+    {
+      "description": "Fractional seconds are ordered numerically within the same second.",
+      "test_group": "base",
+      "test_type": "comparison",
+      "input": {
+        "input_scheme": "datetime",
+        "versions": [
+          "2024-01-01T00:00:00.900Z",
+          "2024-01-01T00:00:00.123Z",
+          "2024-01-01T00:00:00.090Z"
+        ]
+      },
+      "expected_output": [
+        "2024-01-01T00:00:00.090Z",
+        "2024-01-01T00:00:00.123Z",
+        "2024-01-01T00:00:00.900Z"
+      ]
+    }
+  ]
+}

--- a/tests/vers_canonical_parse_test.json
+++ b/tests/vers_canonical_parse_test.json
@@ -82,6 +82,38 @@
       "input": "vers:npm/1.0%2G0",
       "expected_failure": true,
       "expected_failure_reason": "non-canonical VERS: invalid percent-encoding in version"
+    },
+    {
+      "description": "Parsing fails for datetime when lowercase t and z are used.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "vers:datetime/2024-01-01t00:00:00z",
+      "expected_failure": true,
+      "expected_failure_reason": "non-canonical VERS: datetime must use uppercase T and Z"
+    },
+    {
+      "description": "Parsing fails for datetime when time colons are percent-encoded.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "vers:datetime/2024-01-01T00%3A00%3A00Z",
+      "expected_failure": true,
+      "expected_failure_reason": "non-canonical VERS: datetime time colons must be unencoded"
+    },
+    {
+      "description": "Parsing fails for datetime when percent-encoding is invalid.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "vers:datetime/2024-01-01T00:00:00%ZZ",
+      "expected_failure": true,
+      "expected_failure_reason": "non-canonical VERS: invalid percent-encoding in version"
+    },
+    {
+      "description": "Parsing fails for datetime when percent-encoded triplets use non-canonical hex case.",
+      "test_group": "base",
+      "test_type": "parse",
+      "input": "vers:datetime/2024-01-01T00%3a00%3a00Z",
+      "expected_failure": true,
+      "expected_failure_reason": "non-canonical VERS: percent-encoding in version is not canonical"
     }
   ]
 }


### PR DESCRIPTION
This PR adds missing datetime tests and clarifications regarding canonicality (see [issue 14](https://github.com/package-url/vers-spec/issues/14) which has been reopened):
- Added datetime comparison/equality tests in datetime_version_cmp_test.json
- Extended canonical parse tests regarding datetime in vers_canonical_parse_test.json 
- Updated spec text in specification.md to clarify datetime canonical form
- Updated vers-types.md to clarify datetime canonical form