### PR TITLE
Update lexicographic-test.json

### DIFF
--- a/tests/lexicographic-test.json
+++ b/tests/lexicographic-test.json
@@ -3,7 +3,7 @@
   "tests": [
     {
       "description": "Simple ASCII ordering (uppercase < lowercase)",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -19,7 +19,7 @@
     },
     {
       "description": "Prefix ordering: shorter prefix sorts first",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -35,7 +35,7 @@
     },
     {
       "description": "Composed vs decomposed (no normalization): 'é' vs 'é' (e + combining acute)",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -51,7 +51,7 @@
     },
     {
       "description": "Composed vs decomposed: 'Å' vs 'Å' (A + combining ring)",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -67,7 +67,7 @@
     },
     {
       "description": "Multi-byte first-byte tie: 'ä' (U+00E4) vs 'é' (U+00E9) — same first UTF-8 byte, compare next byte",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -83,7 +83,7 @@
     },
     {
       "description": "Non-ASCII vs ASCII: emoji sorts after ASCII characters (first UTF-8 byte > ASCII)",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -99,7 +99,7 @@
     },
     {
       "description": "German sharp s vs 'ss' (no normalization)",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",
@@ -115,7 +115,7 @@
     },
     {
       "description": "Different multi-byte leading bytes: U+20AC (Euro) vs U+00E4 ('ä')",
-      "test_group": "utf8-lexicographic",
+      "test_group": "base",
       "test_type": "comparison",
       "input": {
         "input_scheme": "lexicographic",


### PR DESCRIPTION
Updated **test group** from " tf8-lexicographic" to "base" for VERS test schema v0.1 Automated upgrade for VERS test schema v0.2 will convert "base" to "required"