### PR TITLE
New documentation for VERS test schema v0.2

### DIFF
--- a/docs/tests/test-overview.md
+++ b/docs/tests/test-overview.md
@@ -52,7 +52,7 @@ Some key terminology for VERS tests is:
 | VERS component  | One of the 3 components of a VERS string  |
 | VERS data       | Summary term for a VERS string or an object composed of VERS components |
 | VERS Standard   | Refers to the VERS Core Specification                    |
-| VERS tool       | A software program that includes functionality for |
+| VERS tool       | A software program that implements one or more VERS functions such as building or parsing a VERS notation or determining whether a version is contained within VERS **constraints** |
 | VERS type registration | Means that there is a VERS type definition file (JSON) in the `vers-spec` repository |
 | test case       | Is a single test example within a *test file*         |
 | test file       | Is a set of *test cases*                              |

--- a/docs/tests/test-overview.md
+++ b/docs/tests/test-overview.md
@@ -1,53 +1,60 @@
 ---
 id: test-overview
 title: VERS test overview
-sidebar_label: VERS test overview
+sidebar_label: Test overview
 hide_table_of_contents: true
 ---
 
 # VERS test overview
 
-## Tests
+The Version Range Specifier (VERS) specification provides test files to
+support language-neutral testing of VERS implementations. The objectives for
+the VERS test suite is to:
+- Enable tools to demonstrate conformance with the VERS specification as
+  defined in the [VERS Core Specification](https://packageurl.org/docs/vers/specification)
+  or in registered VERS **type** definitions.
+- Help tools identify and fix common problems in VERS data.
 
-The VErsion Range Specifier (VERS) specification provides a JSON Schema and
-test files to support language-neutral testing of VERS implementations. The
-objectives for the VERS test schema and test files are to enable tools to
-conform to the VERS specification for tool functions such as:
-- validate a VERS string
-- parse a VERS string to determine if a version is contained within a range
+The structure of test cases used in VERS test files is defined in a JSON
+schema that is available at: https://packageurl.org/schemas/vers-test.schema-0.2.json.
 
-The test files are available at: [`vers-spec/tests/`](https://github.com/package-url/vers-spec/tree/main/tests).
-Each test file is in JSON format with a naming convention based on: `<version-scheme>_<range OR version>_<test-type>_test.json.`
+## Conformance
+Since the primary goal for the VERS test suite is to help VERS tools achieve
+and demonstrate conformance with the VERS specification, it is important to
+state what we mean by conformance. Conformance for VERS is defined in the
+VERS specification files at: https://github.com/package-url/vers-spec/tree/main/docs/specification/standard.
 
-Two key properties in the VERS test JSON Schema are:
-- Test groups
-- Test types
+A  summary is: "A conforming implementation of Version Range Specifier (VERS)
+shall fully implement and support all elements defined within this Standard,
+including the syntax, components, and semantic requirements for constructing
+and interpreting valid VERS notations."
 
-### Test groups
+Other VERS documentation such as "How to parse and validate VERS" is important
+but not part of the VERS Standard for conformance purposes.
 
-There are two VERS test groups:
-- **base**: Test group for base conformance tests. Base tests are pass/fail.
-- **advanced**: Test group for advanced tests. Advanced tests cover additional
-  capabilities beyond base conformance, while still requiring canonical VERS
-  input.
+Some common words have a very specific meaning for Ecma conformance:
+- "canonical form" means a VERS string or a set of VERS components in the
+  format that matches the Standard for a string or components respectively
+- "normalization" means the process of structuring, standardizing, or
+  converting data to conform to a standard format - i.e. canonical form.
+- "shall" indicates a requirement (Ecma & ISO definition)
+- "should" indicates a recommendation (Ecma & ISO definition)
 
-### Test types
+The VERS Standard requires that:
+- A VERS string is in canonical form or
+- Each VERS component in a set (object) conforms to the VERS Standard.
 
-There are nine VERS test types:
-- **build**: A test to build a canonical VERS string from decoded VERS
-  components.
-- **comparison**: A test to sort an input version string array using the
-  applicable VERS **type** rules.
-- **containment**: A test to determine whether a bare version string is
-  contained within the range of a VERS string.
-- **equality**: A test to check if two input versions strings are equal using
-  the applicable VERS **type** rules.
-- **from_native**: A test to construct a canonical VERS string from a native
-  ecosystem data source.
-- **invert**: A test to invert a VERS string into a canonical VERS string.
-- **merge**: A test to merge an array of VERS strings into a canonical VERS
-  string.
-- **parse**: A test to parse a VERS string into a decoded **type**
-  and a **constraints** list.
-- **roundtrip**: A test to parse a VERS input string and build a canonical
-  VERS output string.
+## Terminology
+Some key terminology for VERS tests is:
+
+| Term            | Definition                                              |
+|-----------------|---------------------------------------------------------|
+| VERS component  | One of the 3 components of a VERS string  |
+| VERS data       | Summary term for a VERS string or an object composed of VERS components |
+| VERS Standard   | Refers to the VERS Core Specification                    |
+| VERS tool       | A software program that includes functionality for |
+| VERS type registration | Means that there is a VERS type definition file (JSON) in the `vers-spec` repository |
+| test case       | Is a single test example within a *test file*         |
+| test file       | Is a set of *test cases*                              |
+| test suite      | Is the entire set of current VERS *test files*        |
+

--- a/docs/tests/test-schema-changes.md
+++ b/docs/tests/test-schema-changes.md
@@ -1,12 +1,12 @@
 ---
 id: test-schema-changes
 title: VERS test schema v0.2 changes
-sidebar_label: Test schema v0.2 changes
+sidebar_label: Test schema changes
 hide_table_of_contents: true
 ---
 
-# VERF test schema v0.2 changes
-The VERStest schema was updated to: https://packageurl.org/schemas/vers-test.schema-0.2.json
+# VERS test schema v0.2 changes
+The VERS test schema was updated to: https://packageurl.org/schemas/vers-test.schema-0.2.json
 on August 4, 2026. This update includes an automated update to all of the VERS
 test suite files at: `vers-spec/tests/`. See a summary of the changes below.
 

--- a/docs/tests/test-schema-changes.md
+++ b/docs/tests/test-schema-changes.md
@@ -22,7 +22,7 @@ This change removes the ambiguity of the **test group** names from the v0.1
 VERS test schema by using names that map to Ecma conformance terminology.
 
 ### Test messages
-**Change**: Renamed **expected_failure_reason** to **expected message**
+**Change**: Renamed **expected_failure_reason** to **expected_message**
 
 The terminology of the v0.1 VERS test schema did not provide a
 way to provide a test case message for the use case:

--- a/docs/tests/test-schema-changes.md
+++ b/docs/tests/test-schema-changes.md
@@ -1,0 +1,58 @@
+---
+id: test-schema-changes
+title: VERS test schema v0.2 changes
+sidebar_label: Test schema v0.2 changes
+hide_table_of_contents: true
+---
+
+# VERF test schema v0.2 changes
+The VERStest schema was updated to: https://packageurl.org/schemas/vers-test.schema-0.2.json
+on August 4, 2026. This update includes an automated update to all of the VERS
+test suite files at: `vers-spec/tests/`. See a summary of the changes below.
+
+The original VERS test suite files for the [VERS test schema v0.1](https://packageurl.org/schemas/vers-test.schema-0.1.json)
+remain available under [vers-spec v1.0.2](https://github.com/package-url/vers-spec/releases/tag/v1.0.2).
+
+### Test groups
+**Change**: Renamed
+- 'base' to 'required'
+- 'advanced' to 'recommended'
+
+This change removes the ambiguity of the **test group** names from the v0.1
+VERS test schema by using names that map to Ecma conformance terminology.
+
+### Test messages
+**Change**: Renamed **expected_failure_reason** to **expected message**
+
+The terminology of the v0.1 VERS test schema did not provide a
+way to provide a test case message for the use case:
+- When an **input** contains an unregistered VERS **type**. This applies to
+  all **test types**. It seems important to document that a VERS **type**
+  is not registered because this means that the VERS **type** is effectively
+  unknown across the tools and databases that implement VERS.
+
+### Test types
+**Change**: Renamed **test type** 'roundtrip' to 'validate'.
+
+The general meaning of a "roundtrip" test was to confirm that a VERS
+tool can parse a canonical VERS into its components and then build a canonical
+VERS from those components - these functions are also known as deserialization
+and serialization. The former 'roundtrip' **test type** did not provide much
+value because the input and output are required to be the same - a VERS tool
+can easily test this "roundtrip" behavior without a test case.
+
+There is a high degree of similarity between the 'parse' and 'validate'
+**test types** in terms of the functions a VERS tool performs. The key
+difference is that the **expected output** from a 'parse' test case is
+an object composed of decoded VERS components and the **expected output**
+from a 'validate' test case is a VERS string. The 'validate' **test type**
+does not require the input VERS string to be in canonical form.
+
+
+
+
+
+
+
+
+

--- a/docs/tests/test-suite.md
+++ b/docs/tests/test-suite.md
@@ -44,7 +44,7 @@ and purpose.
 ### test_group
 There are two VERS **test groups**:
 - 'required': A test case to demonstrate conformance with the VERS
-specification.
+  specification.
 - 'recommended': A test case that is recommended to identify common problems
   in VERS data and how to remediate or normalize them in order to pass the
   'required' tests. The use of 'recommended' test cases is always optional.
@@ -64,7 +64,7 @@ There are nine VERS **test types**:
   contained within the range of a VERS string.
 - 'equality': A test case to check if two input version strings are equal
   using the applicable VERS type rules.
-- 'from_name': A test case to construct a canonical VERS string from a native
+- 'from_native': A test case to construct a canonical VERS string from a native
   ecosystem data source.
 - 'invert': A test case to invert a VERS string into a canonical VERS string.
 - 'merge': A test case to merge an array of VERS strings into a canonical VERS

--- a/docs/tests/test-suite.md
+++ b/docs/tests/test-suite.md
@@ -1,0 +1,112 @@
+---
+id: test-suite
+title: VERS test suite
+sidebar_label: Test suite
+hide_table_of_contents: false
+---
+
+# VERS test suite
+The VERS test suite is intended to help a VERS implementation tool demonstrate
+conformance with the VERS specification. The primary objective is to provide
+clarity about whether a VERS string or a set of VERS components is in
+canonical form.
+
+## Test files
+Each VERS test file is a collection of test cases whose structure is defined
+by the VERS test schema. The current VERS test schema is located at: https://packageurl.org/schemas/.
+
+The VERS test files are currently organized in the folder: https://github.com/package-url/vers-spec/tree/main/tests. Most test file names follow the pattern of VERS **type**
+concatenated with **test type**.
+
+
+## Test cases
+The basic structure of a VERS **test case** is:
+- `description`: string
+- `test_group`: 'required' or 'recommended'
+- `test_type`: see list below
+- `input`: A VERS string or an object of VERS components that is the test case
+  input. The "input" is not required to be in canonical form.
+- `expected_output`: A VERS string or a set of decoded components (canonical
+  form) that is the test case output.
+- `expected_failure`: boolean
+- `expected_message`: string
+
+Each test case is granular such that an expected failure condition covers only
+one error. This means that a test case should only cover an error for a single
+VERS component or a single parsing error related to separator characters. This
+is necessary to keep test cases simple. It is not intended to constrain error
+message handling implemented by a VERS tool.
+
+### description
+The test case **description** should succinctly describe the test case scope
+and purpose.
+
+### test_group
+There are two VERS **test groups**:
+- 'required': A test case to demonstrate conformance with the VERS
+specification.
+- 'recommended': A test case that is recommended to identify common problems
+  in VERS data and how to remediate or normalize them in order to pass the
+  'required' tests. The use of 'recommended' test cases is always optional.
+
+The terminology of 'required' vs 'recommended' matches the use of "shall" vs
+"should" for Ecma conformance. A "shall" statement means 'required'; a
+"should" statement means 'recommended'.
+
+### test_type
+There are nine VERS **test types**:
+
+- 'build': A test case for the function of building a canonical VERS output
+  string from an input of decoded VERS components.
+- 'comparison': A test case to sort an input version string array
+  using the applicable VERS type rules.
+- 'containment': A test case to determine if a bare version string is
+  contained within the range of a VERS string.
+- 'equality': A test case to check if two input version strings are equal
+  using the applicable VERS type rules.
+- 'from_name': A test case to construct a canonical VERS string from a native
+  ecosystem data source.
+- 'invert': A test case to invert a VERS string into a canonical VERS string.
+- 'merge': A test case to merge an array of VERS strings into a canonical VERS
+  string.
+- 'parse': A test case to parse a VERS string into a decoded VERS type and a
+  constraints list.
+- 'validate': A test case for the function of validating a VERS input
+  string. The input is a VERS string (in canonical form or not) and the output
+  is a VERS string in canonical form.
+
+See [`/docs/how-to-parse.md`](https://packageurl.org/docs/vers/how-to-parse#parsing-and-validating-vers-notation) for more information about
+the 'containment', 'parse', and 'validate' **test types**.
+
+### input
+- **input** may be a VERS string or an object containing VERS components.
+- **input** does not need to be in canonical form, but a test case with
+  non-canonical input shall fail when the **test group** is 'required'.
+
+### expected_output
+**expected output** is either a canonical VERS string or an object containing
+a set of decoded VERS components.
+- If **expected_failure** is true, then **expected output** is null.
+- If **expected failure** is false, then **expected output** is required.
+
+### expected_failure
+**expected failure** is true if the test **input** is expected to fail
+according to the function defined by the **test type**.
+
+### expected_message
+**expected message** either documents the reason that a test case results in a
+failure or provides information about the result of the test case. It should
+be descriptive without duplicating the test case **description**.
+- If **expected failure** is true, then **expected message** is
+  required.
+- If **expected failure** is false, then **expected message** is not required,
+  but is recommended when an **input** contains an unregistered VERS **type**.
+  It is important to document that a VERS **type** is not registered because
+  this means that the VERS **type** is effectively unknown across the tools
+  and databases that implement VERS.
+
+The VERS specification does not mandate how a VERS tool natively reports
+the success or failure of a test. Implementation languages that throw
+exceptions or return typed results should return typed errors, i.e.
+a syntactically invalid VERS and a VERS input that fails VERS
+**type**-specific validation should result in different types or enum values.


### PR DESCRIPTION
The changes are a rewrite of the VERS test documentation with 3 files:
- `test-overview.md`: updated with some content moved to other files
- `test-suite.md`: adapted from similar recent PURL doc
- `test-schema-changes.md`: adapted from similar recent PURL doc