### PR TITLE
change pypi_range_roundtrip to pypi_range_validate

### DIFF
--- a/tests/pypi_range_validate_test.json
+++ b/tests/pypi_range_validate_test.json
@@ -2,133 +2,133 @@
   "$schema": "https://packageurl.org/schemas/vers-test.schema-0.2.json",
   "tests": [
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.2",
       "expected_output": "vers:pypi/>0.0.2"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "recommended",
       "test_type": "validate",
       "input": "vers:pypi/0.0.2|0.0.6|0.0.0|0.0.1|0.0.4|0.0.5|0.0.3",
       "expected_output": "vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|0.0.4|0.0.5|0.0.6"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.1",
       "expected_output": "vers:pypi/>0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>=0.0.1",
       "expected_output": "vers:pypi/>=0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<0.0.1",
       "expected_output": "vers:pypi/<0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<=0.0.1",
       "expected_output": "vers:pypi/<=0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/0.0.1",
       "expected_output": "vers:pypi/0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/!=0.0.1",
       "expected_output": "vers:pypi/!=0.0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/*",
       "expected_output": "vers:pypi/*"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.1|<0.1",
       "expected_output": "vers:pypi/>0.0.1|<0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>=0.0.1|<0.1",
       "expected_output": "vers:pypi/>=0.0.1|<0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<0.0.1|>0.1",
       "expected_output": "vers:pypi/<0.0.1|>0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<=0.0.1|>0.1",
       "expected_output": "vers:pypi/<=0.0.1|>0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/0.0.1|>0.1",
       "expected_output": "vers:pypi/0.0.1|>0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/!=0.0.1|>0.1",
       "expected_output": "vers:pypi/!=0.0.1|>0.1"
     },
     {
-      "description": "Roundtrip test for PyPI VERS range.",
+      "description": "Validate test for PyPI VERS range.",
       "test_group": "recommended",
       "test_type": "validate",
       "input": "vers:pypi/0.0.2|0.0.6|>=0.0.0|0.0.1|0.0.4|0.0.5|0.0.3",

--- a/tests/pypi_range_validate_test.json
+++ b/tests/pypi_range_validate_test.json
@@ -3,7 +3,7 @@
   "tests": [
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.2",
       "expected_output": "vers:pypi/>0.0.2"
@@ -17,112 +17,112 @@
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|<0.0.3|0.0.4|<0.0.5|>=0.0.6"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|<=0.0.6|!=0.7|8.0|>12|<15.3"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8",
       "expected_output": "vers:pypi/>0.0.0|>=0.0.1|0.0.2|0.0.3|0.0.4|<0.0.5|>=0.0.6|!=0.8"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.1",
       "expected_output": "vers:pypi/>0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>=0.0.1",
       "expected_output": "vers:pypi/>=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<0.0.1",
       "expected_output": "vers:pypi/<0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<=0.0.1",
       "expected_output": "vers:pypi/<=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/0.0.1",
       "expected_output": "vers:pypi/0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/!=0.0.1",
       "expected_output": "vers:pypi/!=0.0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/*",
       "expected_output": "vers:pypi/*"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>0.0.1|<0.1",
       "expected_output": "vers:pypi/>0.0.1|<0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/>=0.0.1|<0.1",
       "expected_output": "vers:pypi/>=0.0.1|<0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<0.0.1|>0.1",
       "expected_output": "vers:pypi/<0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/<=0.0.1|>0.1",
       "expected_output": "vers:pypi/<=0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/0.0.1|>0.1",
       "expected_output": "vers:pypi/0.0.1|>0.1"
     },
     {
       "description": "Roundtrip test for PyPI VERS range.",
-      "test_group": "recommended",
+      "test_group": "required",
       "test_type": "validate",
       "input": "vers:pypi/!=0.0.1|>0.1",
       "expected_output": "vers:pypi/!=0.0.1|>0.1"


### PR DESCRIPTION
This change applies the VERS test schema v0.2 change of **test type** 'roundtrip' to 'validate' in the file name and in some test cases. 
The changes at the **test group** from 'recommended' to 'required' where the `input` and `expected_output` are equal.
This is an interim change pending a more complete implementation of the new 'validate' **test type**.