### PR TITLE
Update vers-test.schema-0.2.json

### DIFF
--- a/schemas/vers-test.schema-0.2.json
+++ b/schemas/vers-test.schema-0.2.json
@@ -524,7 +524,7 @@
             },
             "required": [
               "input",
-              "expected_failure_reason"
+              "expected_message"
             ]
           }
         },
@@ -553,7 +553,7 @@
             },
             "required": [
               "input",
-              "expected_failure_reason"
+              "expected_message"
             ]
           }
         }


### PR DESCRIPTION
Corrected two instances of `expected_failure_reason` that are not converted to `expected_message` in the `allOf` subschemas.