### PR TITLE
add files for VERS types

### DIFF
--- a/docs/types/definitions/README.md
+++ b/docs/types/definitions/README.md
@@ -1,5 +1,3 @@
-
-
 This directory contains **human-readable documentation** generated from the
 **reference machine-readable JSON VERS type definitions** found in `types/`.
 

--- a/docs/types/definitions/README.md
+++ b/docs/types/definitions/README.md
@@ -1,0 +1,12 @@
+
+
+This directory contains **human-readable documentation** generated from the
+**reference machine-readable JSON VERS type definitions** found in `types/`.
+
+**Do not manually edit these files!**
+
+These documents are **automatically generated** and will be **overwritten** in
+future updates.
+
+All modifications should be made in the reference JSON files located in
+`types/`.

--- a/docs/types/details/vers-type-details-template.md
+++ b/docs/types/details/vers-type-details-template.md
@@ -1,0 +1,36 @@
+
+# Details for VERS type: {'vers-type'}
+The naming convention is `{vers-type}-details.md`
+
+(The following topics are suggestions - they are not required.)
+
+## Definition notes
+{Provide additional information about the VERS **type** definition that is
+more detailed than the notes in the JSON format **type** definition file. This
+information will often be at the VERS component level.}
+
+## Native version scheme
+{Background information about the native version scheme for this VERS **type**}
+
+## Native syntax
+{Description of the native syntax or notation for the version range described
+by this VERS **type**.}
+
+## Native comparator mappings
+{List of mappings from the native range syntax comparators mapping to VERS
+equivalent comparators}
+
+## VERS type history
+
+### Major Changes
+{Provide a list of major changes to the definition of this VERS **type** since
+its original registration. You may want to include links to relevant issues or
+ discussions.}
+
+### Original registration
+{Describe the reason for the original registration of this VERS **type**.
+This will often including summarizing commentary from issues or PRs to
+spare the reader from trying to follow those threads. You may want to include
+links to relevant discussions, issues or PRs.}
+
+## More Information

--- a/schemas/vers-type-definition.schema-0.1.json
+++ b/schemas/vers-type-definition.schema-0.1.json
@@ -74,7 +74,7 @@
       ]
     },
     "native_and_vers_examples": {
-      "title": "Examples of Native Version Range and their VERS equivalent",
+      "title": "Examples of Native Version Ranges and their VERS equivalents.",
       "description": "Optional list of examples of valid, native version ranges mapped to their corresponding canonical VERS syntax.",
       "type": "array",
       "uniqueItems": true,
@@ -173,7 +173,7 @@
         },
         "comparison_procedure": {
           "title": "Version Comparison Procedure",
-          "description": "List of steps describing in plain text the procedure to compare two versions for this VERS type. Comparison also enables sorting constraints for canonical VERS.",
+          "description": "List of steps describing in plain text the procedure to compare two versions for this VERS type. Comparison also enables sorting constraints to build a canonical VERS.",
           "type": "array",
           "uniqueItems": true,
           "items": {
@@ -204,7 +204,7 @@
           ]
         },
         "reference_urls": {
-          "title": "Reference URLs",
+          "title": "Reference URLs for version definitions.",
           "description": "List of informational reference URLs about the version definitions for a VERS type, such as specifications, reference code and related pointers.",
           "type": "array",
           "uniqueItems": true,

--- a/schemas/vers-types-index.schema-0.1.json
+++ b/schemas/vers-types-index.schema-0.1.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema#",
+  "$id": "https://packageurl.org/schemas/vers-type-index.schema-0.1.json",
+  "title": "VErsion Range Specifier (VERS) types index",
+  "description": "An index of registered VERS types.",
+  "type": "array",
+  "additionalItems": false,
+  "items": {
+    "type": "string"
+  }
+}

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,33 @@
+### VERS Type Definitions
+
+This directory contains the machine-readable definitions of all currently
+registered VERS types, one JSON file for each type. These JSON files serve as
+the reference for VERS **type** specifications.
+
+## Definitions
+
+Each JSON file named `<vers-type>-definition.json` in this directory follows
+the VERS Type Definition Schema standard. The goals are:
+
+- Consistency across all VERS **types**.
+- Machine-readability for validation and automation.
+- Standardized structure defining 'constraints' including 'comparators' and
+  'versions'.
+
+## Usage
+
+- These JSON files are the the authoritative source for defining, validating
+  and testing VERS **types**.
+- They should be referenced by tools, libraries, and documentation generators.
+
+## Related files
+
+The VERS **type** index provides a simple index of registered VERS types at:
+[**vers-types-index.json**](https://github.com/package-url/vers-spec/blob/main/vers-types-index.json).
+
+## Contributions
+
+- Modifications must be made to these JSON files directly.
+- The type definitions, tests and index are validated for consistency on
+  commit.
+- Documentation files are generated from these JSON files.


### PR DESCRIPTION
- Editorial changes to descriptions in `vers-type-definition.schema-0.1.json`
- Added `vers-types-index.schema-0.1.json`
- Added folder `docs/types/definitions` and seeded it with `README.md`
- Added folder `docs/types/details` and seeded it with 'vers-type-details-template.md'
- Added folder `types/` and seeded it with `README.md`