### PR TITLE
Complete Ecma document set for VERS

### DIFF
--- a/docs/specification/standard/About.md
+++ b/docs/specification/standard/About.md
@@ -1,0 +1,29 @@
+# About this Specification
+
+The document at [https://tc54.org/vers/](https://tc54.org/vers) is the
+most accurate and up-to-date Version Range Specifier specification.
+
+This document is available as [a single page](https://ecma-tc54.github.io/ECMA-4XX/)
+and as [multiple pages](https://ecma-tc54.github.io/ECMA-4XX/multipage/).
+
+# Contributing to this Specification
+
+This specification is developed on GitHub with the help of the VERS
+community. There are a number of ways to contribute to the development of
+this specification:
+
+* GitHub Repository: [https://github.com/Ecma-TC54/ECMA-xxx-VERS](https://github.com/Ecma-TC54/ECMA-xxx-VERS)
+* Issues: [All Issues](https://github.com/Ecma-TC54/ECMA-xxx-VERS/issues),
+  [File a New Issue](https://github.com/Ecma-TC54/ECMA-xxx-VERS/issues/new)
+* Pull Requests: [All Pull Requests](https://github.com/Ecma-TC54/ECMA-xxx-VERS/pulls),
+  [Create a New Pull Request](https://github.com/Ecma-TC54/ECMA-xxx-VERS/pulls/new)
+* Editors:
+  * [John Horan](mailto:jmhoran@aboutcode.org)
+  * [Michael Herzog](mailto:mjherzog@aboutcode.org)
+  * [Philippe Ombredanne](mailto:pombredanne@aboutcode.org)
+  * [Steve Springett](mailto:steve.springett@owasp.org)
+* Community:
+  * Chat: [Slack Channel](https://aboutcode-org.slack.com/archives/C097F17058F)
+
+Refer to the [colophon](https://ecma-tc54.github.io/ECMA-4XX/#sec-colophon)
+for more information on how this document was created.

--- a/docs/specification/standard/Clause-1-Scope.md
+++ b/docs/specification/standard/Clause-1-Scope.md
@@ -1,4 +1,4 @@
-# Scope
+# 1 Scope
 This Standard defines the Version Range Specifier (VERS) syntax for specifying
 a software version range notation as a compact alternative to enumerating a
 list of software versions. The primary use cases for VERS are identifying

--- a/docs/specification/standard/Clause-2-Conformance.md
+++ b/docs/specification/standard/Clause-2-Conformance.md
@@ -1,4 +1,4 @@
-# Conformance
+# 2 Conformance
 
 A conforming implementation of Version Range Specifier (VERS) Standard shall
 fully implement and support all elements defined within this Standard,

--- a/docs/specification/standard/Clause-3-Normative-References.md
+++ b/docs/specification/standard/Clause-3-Normative-References.md
@@ -1,4 +1,4 @@
-# Normative References
+# 3 Normative References
 
 The following documents are referred to in the text in such a way that some or
 all of their content constitutes requirements of this document. For dated

--- a/docs/specification/standard/Clause-4-Overview.md
+++ b/docs/specification/standard/Clause-4-Overview.md
@@ -1,4 +1,4 @@
-# Overview
+# 4 Overview
 
 This Clause contains a non-normative overview of the VERS specification.
 

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -110,7 +110,7 @@ A **comparator** shall be one of the following:
   Debian package. This includes past, current and possible future versions.
 
 #### Version strings
-A Version is an ASCII string.
+A **version** is an ASCII string.
 
 A single **version** in a **constraints** string means that a version
 equal to this version satisfies the range specification. Equality is based on

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -1,0 +1,274 @@
+# VERS specification
+
+VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string composed of
+three components:
+
+    scheme:type/constraints|
+
+Components are separated by a specific character for unambiguous parsing.
+
+**Table 1 —  Components of a VERS**
+
+| Component           | Requirement | Description|
+| ------------------- | ----------- |:------------------------------------------------------ |
+| scheme              | Required    | The URL scheme with the constant value of "vers". |
+| type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
+| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between version-constraints is a single pipe '\|'. |
+
+## Separator characters
+This is how each of the Separator Characters is used:
+- ':' (colon) is the separator between **scheme** and **type**
+- '/' (slash) is the separator between **type** and **constraints**
+- '|' (pipe) is the separator between **constraints**
+
+**Example 1 (Informative): npm**
+
+    vers:npm/1.2.3|>=2.0.0|<5.0.0
+
+**Example 2 (Informative): gem**
+
+    vers:gem/>=2.2.0|!=2.2.1|<2.3.0`
+
+## A VERS is a URI scheme
+
+A VERS is a valid URI scheme that conforms to URI definitions or
+specifications at: - https://tools.ietf.org/html/rfc3986
+
+## VERS components
+
+### Scheme
+- The **scheme** is a constant with the value "vers".
+- The **scheme** shall be followed by an unencoded colon ':'.
+
+### Type
+- The **type** shall be composed only of ASCII letters and numbers,
+  period '.', and dash '-'.
+- The **type** shall start with an ASCII letter.
+- The **type** shall not be percent-encoded.
+- The **type** is case insensitive. The canonical form is lowercase.
+- The **type** shall be followed by a slash '/'.
+
+A **type** defines:
+
+- the specific notation and conventions used for a version string encoded
+  according to this type
+- how two versions are compared to determine if a version is inside or
+  outside a range
+- how a type-specific range notation can be transformed into VERS
+  notation
+
+A **type** also defines:
+- how to compare two version strings using **comparators**
+- the structure (if any) of a **version** string such as "1.2.3". For
+  example, the "semver" specification for version numbers defines a version as
+  composed primarily of three dot-separated numeric segments named "major",
+  "minor" and "patch".
+
+By convention a **type** should be the same as the
+PURL **type** for a given package ecosystem. It is, however, allowed to
+define a **type** that does not match an existing PURL **type**
+such as a scheme that applies to a single package or project.
+
+### constraints
+- The **constraints** component shall be preceded by an unencoded
+  '/' slash separator when not empty.
+- Each instance of the **constraints** component is composed of either
+  a single **version** as in '1.2.3' or the combination of a **comparator**
+  and a **version** as in '>=2.0.0'.
+- A **comparator** always precedes the **version** with no characters allowed
+  between the **comparator** and the **version**
+- Multiple **constraints** strings shall be separated by an unencoded
+  pipe '|'. The pipe "|" has no special meaning other than being a separator.
+
+#### Comparator characters
+A **comparator** is composed of these ASCII characters:
+- the Equals character: '=' (equals, '=')
+- the Not Equals character: '!' (exclamation mark, '!')
+- the Greater Than character: '>' (greater than, '>')
+- the Less Than character: '<' (less than, '<')
+- the Asterisk character: '\*' (asterisk, '*')
+
+A **comparator** shall be one of the following:
+- '=' is the Equality **comparator**. This means a version shall be equal to
+  the provided version.
+- '!=' is the Inequality **comparator**. This means that a version shall not
+  be equal to the provided version and it shall be excluded from the range.
+  For example: '!=1.2.3' means that version   "1.2.3" is excluded.
+- '<' is the Less-than **comparator**. This includes all versions less than
+  the provided version.
+- '<=': is the Less-or-equal **comparator**. This includes all versions less
+  than or equal to the provided version. For example '<=1.2.3' means
+  less than or equal to "1.2.3".
+- '>' is the Greater-than **comparator**. This includes all versions greater
+  than the provided version.
+- '>=' is the Greater-or-equal **comparator**. This includes all versions
+  greater than or equal to the provided version. For example '>=1.2.3'
+  means greater than or equal to "1.2.3".
+- The special Asterisk '\*' **comparator** matches any version. It shall be
+  used alone and exclusive of any other constraint and shall not be followed
+  by a version. For example, 'vers:deb/\*' represents all versions of a
+  Debian package. This includes past, current and possible future versions.
+
+#### Version strings
+A Version is an ASCII string.
+
+A single **version** in a **constraints** string means that a version
+equal to this version satisfies the range specification. Equality is based on
+the equality of two normalized version strings according to the applicable
+**type**. For most schemes, this is a simple string equality. A
+**type** may, however, define normalization and other rules for
+equality such as the "pypi" rules from PEP 440.
+
+A package version satisfies a set of **constraints** if it is
+contained within any of the intervals defined by the **constraints**.
+
+## Normalized, canonical representation and validation
+
+VERS construction and validation rules are designed such that a VERS is
+easy to read and understand by humans and straightforward to process
+with tools. The rules are designed to prevent the creation of empty or
+impossible version ranges.
+
+- A VERS string shall already be in canonical form. Non-canonical
+  (unnormalized) forms are invalid and tools shall report an error instead of
+  normalizing them automatically.
+- A version range specifier contains only printable ASCII letters,
+  digits and punctuation.
+- ASCII whitespace is not permitted in a VERS string. Tools shall report an
+  error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or
+  LF (0x0A), is used.
+- The VERS **scheme** and **type** are always lowercase as in
+  'vers:npm'.
+- Versions are case-sensitive. A **type** may specify
+  its own case sensitivity.
+- If a version in a **constraints** string contains any of these characters:
+  '>', '<', '=', '!', '*', '|', '%', these characters shall be
+  percent-encoded using URI percent-encoding rules.
+- Percent-encoding in versions shall be canonical. Tools shall report an error
+  for invalid or non-canonical percent-encoded sequences.
+
+The list of **constraints** strings for a range are like a set of
+signposts in the version timeline of a package. The separators do not mean
+"and" or "or". They are separators in a sequence of **constraints**.
+
+With a few simple validation rules, we can avoid the creation of most empty or
+impossible version ranges. These rules are:
+
+- Constraints are sorted by version. The canonical ordering is the
+  version order. The ordering of **constraints** components
+  is significant for validity: tools shall report an error for
+  non-canonical ordering.
+- Versions are unique. Each version shall be unique in a range
+  and can occur only once in any **constraints** component of
+  VERS, regardless of the **comparators**. Tools shall report an
+  error for duplicated versions.
+- There can be only one asterisk: if used, '\*' shall occur only once and
+  alone in a range, without any other constraint or version.
+
+Starting from a de-duplicated and sorted list of constraints, these
+extra rules apply to the **comparators** of any two contiguous constraints:
+
+- A constraint using the '!=' **comparator** can be followed by a constraint
+  using any **comparator** (any of '=', '!=', '>', '>=', '<', '<=') or no
+  constraint.
+
+Ignoring all constraints with the '!=' **comparator**:
+
+- A constraint using the '=' **comparator** shall be followed only by a
+  constraint with one of   '=', '>', or '>=' as the **comparator** or no
+  constraint.
+
+Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
+of constraints shall be an alternation of Greater-than and Lesser-than
+**comparators**:
+- A constraint using '\<' and '\<=' shall be followed by one of '>' or '>='
+  (or no constraint).
+- A constraint using '>' and '>=' shall be followed by one of '\<' or '\<='
+  (or no constraint).
+
+Tools shall report an error for such invalid ranges.
+
+### Using version range specifiers
+
+The primary VERS use case is to test if a version is within a range.
+A version is within a version range if it falls within any of the intervals
+defined by a range. Otherwise, the version is outside of the version
+range.
+
+Some important use cases derived from this include:
+
+- **Resolve a version range specifier to a list of specific versions.**
+
+  In this case, the input is one or more known versions of
+  a package. Each version is then tested to check if it lies inside or
+  outside the range. For example, given a vulnerability and the VERS
+  describing the vulnerable versions of a package, this process is
+  used to determine if an existing package version is vulnerable.
+
+- **Select one of several versions that are within a range.**
+
+  In this case, with the input of several versions that are within a
+  range and several packages that express package dependencies
+  qualified by a version range, a package management tool will
+  determine and select the set of package versions that satisfy
+  the version range constraints of all of the dependencies. This
+  usually requires deploying heuristics and algorithms (possibly
+  as complex as SAT solvers) that are ecosystem- and tool-specific
+  and outside of the scope of this specification. VERS could
+  be used in tandem with PURL to provide an input to this dependency
+  resolution process.
+
+### Examples
+
+For example, to define a set of versions that contains either version
+"1.2.3", or any versions greater than or equal to "2.0.0" but less than
+"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
+the version range specifier will be:
+
+    vers:npm/1.2.3|>=2.0.0|<5.0.0
+
+This is an example of how to read a set of **constraints** in version
+order from left to right to determine the versions that are included in a
+VERS notation. In this case you process in order:
+- Include a single version "1.2.3"
+- Include versions that are ">=2.0.0"
+- Stop including versions when you reach the constraint "<5.0.0"
+
+Other examples are:
+
+#### A single version in an "npm" package dependency:
+For a package dependency originally seen as a dependency on version "1.2.3" in
+a `package.json` manifest file the version range specification is:
+
+    vers:npm/1.2.3
+
+#### A list of versions, enumerated:
+    vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
+
+#### A complex statement about a vulnerability in a "maven" package:
+For a "maven" package vulnerability that affects multiple branches,
+each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
+Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
+Apache TomEE 1.0.0-beta1 - 1.7.5.`
+
+- A normalized VERS notation is:
+
+      vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
+
+- An alternative is to use four VERS notations to cover the same range using
+  one VERS for each of the vulnerable "branches":
+
+      vers:tomee/>=1.0.0-beta1|<=1.7.5
+      vers:tomee/>=7.0.0-M1|<=7.0.7
+      vers:tomee/>=7.1.0|<=7.1.2
+      vers:tomee/>=8.0.0-M1|<=8.0.1
+
+  See also: https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/
+
+#### Converting RubyGems custom syntax for dependencies:
+Note how the pessimistic version constraint is expanded for the RubyGems
+dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
+
+- The VERS notation is:
+
+      vers:gem/>=2.2.0|!=2.2.1|<2.3.0

--- a/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
+++ b/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
@@ -92,17 +92,6 @@ The definition of native and VERS range equivalents for a VERS type. This inform
 | vers_range             | String   | Required        | The VERS range that corresponds to the native range example. |
 | note                   | String   | Optional        | Extra note text.                                             |
 
-
-
-**Location:** /examples
-**Property:** examples (Required)
-**Type:** array (of String)
-**Pattern Constraint:** ^pkg:\[a-z\]\[a-z0-9-\\.\]+/.\*\$
-
-Example of valid, canonical PURLs for this package type. Each item of this array shall be a string.
-
-_All items shall be unique._
-
 **6.6 Note**
 
 **Location:** /note

--- a/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
+++ b/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
@@ -1,0 +1,123 @@
+**6 VERS Type Definition Schema**
+
+The VERS Type Definition JSON Schema is the reference data model that is used to define VERS types in a structured way. Each VERS type is specified in a JSON document that matches this schema. These JSON documents are then used to generate VERS type documentation and to support VERS libraries and tools so that they can more easily parse, build, and validate PURLs by type in a consistent and standardized manner across programming languages and technology stacks.
+
+**Location:** /
+**Type:** Object
+
+Schema to specify a Version Range Specifier (VERS) type as a structured definition.
+
+**Table 2: Properties for the root object**
+
+| **Property**          | **Type** | **Requirement** | **Description**                                                                                         |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------|
+| type                  | String   | Required        | The type string for this VERS type.                                                                     |
+| type_name             | String   | Required        | The name for this VERS ty                                                                               |
+| description           | String   | Required        | The description of this VERS type.                                                                      |
+| vers_examples         | Array    | Required        | Examples for valid VERS ranges for this VERS type.                                                      |
+| native_and_vers_equivalent_examples | Array  | Optional | List of examples of valid, native version ranges mapped to their corresponding VERS syntax.        |
+| note                  | String   | Optional        | Note about this VERS type.                                                                              |
+| reference_urls        | Array    | Optional        | List of informational reference URLs about this VERS type, such as specifications, reference code and related pointers |
+
+**6.1 VERS type**
+
+**Location:** /type
+**Property:** type (Required)
+**Type:** String
+**Pattern Constraint:** ^\[a-z\]\[a-z0-9-\\.\]+\$
+
+The type string for this VERS type.
+
+**Example 1 (Informative)**
+
+maven
+
+**Example 2 (Informative)**
+
+npm
+
+**Example 3 (Informative)**
+
+pypi
+
+**6.2 Type name**
+
+**Location:** /type_name
+**Property:** type_name (Required)
+**Type:** String
+
+The name for this VERS type.
+
+**Example 1 (Informative)**
+
+Apache Maven Dependency Version Requirement
+
+**Example 2 (Informative)**
+
+npm version range
+
+**6.3 Description**
+
+**Location:** /description
+**Property:** description (Required)
+**Type:** String
+
+The description of this VERS type.
+
+**6.4 VERS examples**
+
+**Location:** /vers_examples
+**Property:** vers_examples (Required)
+**Type:** Array (of String)
+**Pattern Constraint:** ^vers:[a-z][a-z0-9-\\.]+/.*$
+
+Examples of valid VERS ranges for this VERS type.
+
+_All items shall be unique._
+
+**6.5 Native and VERS equivalent examples**
+
+**Location:** /native_and_vers_equivalent_examples
+**Property:** native_and_vers_equivalent_examples (Optional)
+**Type:** Object
+
+The definition of native and VERS range equivalents for a VERS type. This information is optional for a VERS type.
+
+
+**Table 3: Properties for the native_and_vers_equivalent_examples object**
+
+| **Property**           | **Type** | **Requirement** | **Description**                                              |
+| ---------------------- | -------- | --------------- | ------------------------------------------------------------ |
+| native_range           | String   | Required        | Example of a native range for this VERS type.                |
+| vers_range             | String   | Required        | The VERS range that corresponds to the native range example. |
+| note                   | String   | Optional        | Extra note text.                                             |
+
+
+
+**Location:** /examples
+**Property:** examples (Required)
+**Type:** array (of String)
+**Pattern Constraint:** ^pkg:\[a-z\]\[a-z0-9-\\.\]+/.\*\$
+
+Example of valid, canonical PURLs for this package type. Each item of this array shall be a string.
+
+_All items shall be unique._
+
+**6.6 Note**
+
+**Location:** /note
+**Property:** note (Optional)
+**Type:** String
+
+Note about this VERS type.
+
+**6.7 Reference URLs**
+
+**Location:** /reference_urls
+**Property:** reference_urls (Optional)
+**Type:** array (of String)
+**Format:** URI as specified in [RFC 3986](https://www.ietf.org/rfc/rfc3986.html)
+
+Optional list of informational reference URLs about this VERS type. Each item of this array shall be a string.
+
+_All items shall be unique._


### PR DESCRIPTION
Renamed documents in doc/specification/standard to match the clause numbering and titles for Ecma format.
Reference issue #81
