### PR TITLE
Update Clause 5 VERS Specification

### DIFF
--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -1,6 +1,6 @@
 # 5 VERS specification
 
-VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string
+VERS stands for "Version Range Specifier". A VERS is an ASCII URI string
 composed of three components:
 
     scheme:type/constraints|
@@ -11,15 +11,14 @@ Components are separated by a specific character for unambiguous parsing.
 
 | Component           | Requirement | Description|
 | ------------------- | ----------- |:------------------------------------------------------ |
-| scheme              | Required    | The URL scheme with the constant value of "vers". |
-| type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
-| constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between constraints is a single pipe '\|'. |
+| scheme | Required    | The URI scheme with the constant value of 'vers'. |
+| type   | Required    | The Version Range Specifier type such as 'deb', 'npm', 'pypi' 'semver' etc. |
+| constraints | Required | A sequence of one or more version ranges. |
 
-## 5.1 Separator characters
-This is how each of the Separator Characters is used:
-- ':' (colon) is the separator between **scheme** and **type**
-- '/' (slash) is the separator between **type** and **constraints**
-- '|' (pipe) is the separator between **constraints**
+## 5.1 A VERS is a URI scheme
+
+A VERS is a valid URI scheme that conforms to URI definitions or
+specifications at: https://tools.ietf.org/html/rfc3986.
 
 **Example 1 (Informative): npm**
 
@@ -29,12 +28,13 @@ This is how each of the Separator Characters is used:
 
     vers:gem/>=2.2.0|!=2.2.1|<2.3.0`
 
-## 5.2 A VERS is a URI scheme
+## 5.2 Separator characters
+This is how each of the Separator Characters is used:
+- ':' (colon) is the separator between **scheme** and **type**
+- '/' (slash) is the separator between **type** and **constraints**
+- '|' (pipe) is the separator between segments of **constraints**
 
-A VERS is a valid URI scheme that conforms to URI definitions or
-specifications at: - https://tools.ietf.org/html/rfc3986
-
-## 5.3 VERS components
+## 5.3 Rules for each VERS component
 
 ### 5.3.1 Scheme
 - The **scheme** is a constant with the value "vers".
@@ -50,52 +50,55 @@ specifications at: - https://tools.ietf.org/html/rfc3986
 
 A **type** defines:
 
-- the specific notation and conventions used for a version string encoded
+- the specific notation and conventions used for **constraints** encoded
   according to this **type**
+- how a **type**-specific range notation can be transformed into VERS
+  **constraints**
 - how two versions are compared to determine if a version is inside or
   outside a range
-- how a **type**-specific range notation can be transformed into VERS
-  notation
 - how to compare two version strings using **comparators**
-- the structure (if any) of a **version** string such as "1.2.3". For
-  example, the "semver" specification for version numbers defines a version as
+- the structure of a **version** string such as "1.2.3". For example, the
+  "semver" specification for version numbers defines a version as
   composed primarily of three dot-separated numeric segments named "major",
   "minor" and "patch".
 
 By convention a **type** should be the same as the PURL **type** for a given
-package or software ecosystem. It is, however, allowed to define a **type**
+package or software ecosystem. It is, however, permissible to define a **type**
 that does not match an existing PURL **type** such as a version scheme that
 applies to a single package or project or a general purpose version scheme
-like 'semver-2.0.0'.
+like 'semver'.
 
-This Standard includes the VERS Definition Schema but it does not include the
-set of current "registered" VERS type (JSON format) definition files because
-there are ongoing additions and changes to these files. The set of current "registered" VERS type definition files are located at: https://www.packageurl.org/vers-types/. Registration refers to the Package-URL community process for
-adding a new VERS type.
+This Standard includes the *VERS Type Definition Schema* but it does not
+include the set of current "registered" VERS type definition files (in JSON
+format) because there are ongoing additions and changes to these files. The
+current "registered" VERS **type** definition files are located at: https://www.packageurl.org/vers-types/. Registration refers to the Package-URL community process for adding a new VERS **type**.
 
-There are two rules related to the set of registered VERS type definitions for conforming tools to validate the VERS type component of a VERS notation:
+There are two rules related to the set of registered VERS **type** definitions for conforming tools to validate the VERS **type** component:
 
-- If a VERS **type** is registered, then a VERS notation is invalid if it does
+- If a VERS **type** is registered, then a VERS is invalid if it does
   not conform to all of the rules for the corresponding VERS **type**
   definition.
 - If a VERS **type** is not registered, then the **type** component is valid
   if it conforms to the rules stated in the **type** component rules in this
-  Clause of the Standard. In this case a tool should report a warning that the
-  VERS type is not registered.
+  Clause of the Standard. In this case tools should report a warning that the
+  VERS **type** is not registered.
 
 ### 5.3.3 Constraints
 - The **constraints** component shall be preceded by an unencoded
   '/' slash separator when not empty.
-- Each instance of the **constraints** component is called a **constraint**.
+- Each segment of the **constraints** component is called a **constraint**.
   Each **constraint** is composed of either a single **version** as in
   '1.2.3' or the combination of a **comparator** and a **version** as in
   '>=2.0.0'.
 - A **comparator** always precedes the **version** with no characters allowed
   between the **comparator** and the **version**.
-- Multiple **constraints** shall be separated by an unencoded
+- Multiple **constraints** segments shall be separated by an unencoded
   pipe '|'. The pipe "|" has no special meaning other than being a separator.
+- There is no limit on the number of **constraints** segments.
 
-#### 5.3.1 Comparators
+The sequence of **constraints** represents distinct intervals in the version timeline of a package. The separators do not mean "and" or "or". They are separators in a sequence of **constraints** segments.
+
+#### 5.3.3.1 Comparators
 A **comparator** is composed of these ASCII characters:
 - the Equals character: '=' (equals, '=')
 - the Not Equals character: '!' (exclamation mark, '!')
@@ -106,7 +109,7 @@ A **comparator** is composed of these ASCII characters:
 A **comparator** shall be one of the following:
 - '!=' is the Inequality **comparator**. This means that a version shall not
   be equal to the provided version and it shall be excluded from the range.
-  For example: '!=1.2.3' means that version   "1.2.3" is excluded.
+  For example: '!=1.2.3' means that version "1.2.3" is excluded.
 - '<' is the Less-than **comparator**. This includes all versions less than
   the provided version.
 - '<=': is the Less-or-equal **comparator**. This includes all versions less
@@ -118,81 +121,64 @@ A **comparator** shall be one of the following:
   greater than or equal to the provided version. For example '>=1.2.3'
   means greater than or equal to "1.2.3".
 - The special Asterisk '\*' **comparator** matches any version. It shall be
-  used alone and exclusive of any other constraint and shall not be followed
-  by a version. For example, 'vers:deb/\*' represents all versions of a
-  Debian package. This includes past, current and possible future versions.
+  used alone and exclusive of any other **constraint** and shall not be
+  followed by a **version**. For example, 'vers:deb/\*' represents all
+  versions of a Debian package. This includes past, current and possible
+  future versions.
 
 There is no Equality **comparator** (equals, '=') because a **version**
 without a **comparator** asserts equality. For example `vers:npm/1.2.3` means
 that the **version** is equal to "1.2.3". If a **constraint** string starts
 with '=', tools shall report an error.
 
-#### 5.3.2 Version**
+#### 5.3.3.2 Version**
 A **version** is an ASCII string.
+- A **version** contains only printable ASCII letters, digits and punctuation.
+- ASCII whitespace is not permitted in a VERS string except for a
+  percent-encoded space (' '). Tools shall report an error if any other  whitespace character, for example tab or line feed, is used.
+- If a **version** contains any of these characters:
+  '>', '<', '=', '!', '*', '|', '%', these characters shall be
+  percent-encoded using URI percent-encoding rules.
+- Tools shall report an error for invalid percent-encoded sequences.
 
-A single **version** in a **constraint** string means that a version
-equal to this version satisfies the range specification. Equality is based on
-the equality of two normalised version strings according to the applicable
-**type**. For most schemes, this is a simple string equality. A
-**type** may, however, define normalisation and other rules for
-equality such as the "pypi" rules from PEP 440.
+A single **version** in a **constraint** means that a package version equal to this version satisfies the range specification. Equality is based on the
+equality of two normalised version strings according to the applicable **type**. For most schemes, this is a simple string equality. A **type** may, however,
+define normalisation or other rules for equality such as the "pypi" rules from PEP 440.
 
-A package version satisfies a set of **constraints** if it is
-contained within any of the intervals defined by the **constraints**.
+A package version satisfies VERS **constraints** if it is contained within any of the segments defined by the **constraints**.
 
 ## 5.4 VERS validation rules
 
 VERS validation rules are designed such that a VERS notation is easy for a
 human to read and understand, and straightforward for tools to process. The
 rules are also designed to prevent the creation of empty or impossible version
-ranges.
+ranges. These rules are:
 
-- Tools shall report an error for an invalid VERS string.
-- A version range specifier contains only printable ASCII letters,
-  digits and punctuation.
-- ASCII whitespace is not permitted in a VERS string. Tools shall report an
-  error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or
-  LF (0x0A), is used.
-- The VERS **scheme** and **type** are always lowercase as in 'vers:npm'.
-- Versions are case-sensitive. A **type** may specify
-  case sensitivity for that **type**.
-- If a version in a **constraint** string contains any of these characters:
-  '>', '<', '=', '!', '*', '|', '%', these characters shall be
-  percent-encoded using URI percent-encoding rules.
-- Tools shall report an error for invalid percent-encoded sequences.
-
-The list of **constraint** strings represent distinct intervals in the version
-timeline of a a package. The separators do not mean "and" or "or". They are
-separators in a sequence of **constraints**.
-
-With a few simple validation rules, we can avoid the creation of most empty or
-impossible version ranges. These rules are:
-
-- **Constraints** shall be sorted by version order. The ordering of the
-  **constraint** instances is significant for validity: tools shall report
+- **Constraints** shall be sorted by **version** order. The ordering of the
+  **constraints** segments is significant for validity: tools shall report
   an error for invalid ordering.
-- Versions are unique. Each version shall be unique in a **constraints**
-  string and can occur only once in any **constraint**, regardless of the **comparators**. Tools shall report an error for duplicated versions.
-- There can be only one asterisk in a **constraints** string: '\*' shall occur
-  only once and alone in a **constraints** string.
+- **Versions** are unique. Each version shall be unique within a
+  **constraints** instance, and can occur only once in any **constraint**, regardless of the **comparators**. Tools shall report an error for
+  duplicated **versions**.
+- There can be only one asterisk in a **constraints** instance: '\*' shall
+  occur only once and alone in **constraints** instance.
 
 Starting from a de-duplicated and sorted list of **constraints**, the
 following rules apply to the **comparators** of any two contiguous
 **constraints**:
 
-- A constraint using the '!=' **comparator** can be followed by a constraint
-  using any **comparator** (any of '=', '!=', '>', '>=', '<', '<=') or no
-  constraint.
+- A **constraint** using the '!=' **comparator** can be followed by a
+  **constraint** using a **comparator** (any of '!=', '>', '>=', '<', '<=') or no **constraint**.
 - Ignoring all **constraints** with the '!=' **comparator**, an equality
-  **constraint** shall be followed only by a **constraint** with
-  one of **comparators**: '=', '>', or '>=' or no **constraint**.
-- Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
-  of **constraints** shall be an alternation of Greater-than and Lesser-than
-  **comparators**:
-- A constraint using '\<' and '\<=' shall be followed by one of '>' or '>='
-  (or no constraint).
-- A constraint using '>' and '>=' shall be followed by one of '\<' or '\<='
-  (or no constraint).
+  **constraint** shall be followed only by a **constraint** with one of the **comparator** characters: '>', or '>=', or no **comparator** (for equality)
+  or no **constraint**.
+- Ignoring all constraints with no **comparator (equality) or the '!='
+  **comparator**, the sequence of **constraints** shall be an alternation of Greater-than and Lesser-than **comparators**:
+- A **constraint** using '\<' or '\<=' shall be followed by one of '>' or
+  '>=' (or no **constraint**).
+- A **constraint** using '>' or '>=' shall be followed by one of '\<' or
+  '\<=' (or no **constraint**).
 
-Tools shall report an error for an invalid sequence of **constraints**.
+Tools shall report an error for an invalid sequence of **constraints**
+segments.
 

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -174,7 +174,7 @@ ranges. These rules are:
 
 Starting from a de-duplicated and sorted list of **constraints**, the
 following rules apply to the **comparators** of any two contiguous
-**constraints**:
+**constraints** segments:
 
 - A **constraint** using the '!=' **comparator** can be followed by a
   **constraint** using a **comparator** (any of '!=', '>', '>=', '<', '<=') or no **constraint**.

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -1,4 +1,4 @@
-# VERS specification
+# 5 VERS specification
 
 VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string
 composed of three components:
@@ -15,7 +15,7 @@ Components are separated by a specific character for unambiguous parsing.
 | type                | Required    | The version specification type such as "semver", "npm", "deb", etc. |
 | constraints         | Required    | Version constraints may be repeated as many times as needed to accurately reflect the intended range. The separator between constraints is a single pipe '\|'. |
 
-## Separator characters
+## 5.1 Separator characters
 This is how each of the Separator Characters is used:
 - ':' (colon) is the separator between **scheme** and **type**
 - '/' (slash) is the separator between **type** and **constraints**
@@ -29,18 +29,18 @@ This is how each of the Separator Characters is used:
 
     vers:gem/>=2.2.0|!=2.2.1|<2.3.0`
 
-## A VERS is a URI scheme
+## 5.2 A VERS is a URI scheme
 
 A VERS is a valid URI scheme that conforms to URI definitions or
 specifications at: - https://tools.ietf.org/html/rfc3986
 
-## VERS components
+## 5.3 VERS components
 
-### Scheme
+### 5.3.1 Scheme
 - The **scheme** is a constant with the value "vers".
 - The **scheme** shall be followed by an unencoded colon ':'.
 
-### Type
+### 5.3.2 Type
 - The **type** shall be composed only of ASCII letters and numbers,
   period '.', and dash '-'.
 - The **type** shall start with an ASCII letter.
@@ -56,31 +56,46 @@ A **type** defines:
   outside a range
 - how a **type**-specific range notation can be transformed into VERS
   notation
-
-A **type** also defines:
 - how to compare two version strings using **comparators**
 - the structure (if any) of a **version** string such as "1.2.3". For
   example, the "semver" specification for version numbers defines a version as
   composed primarily of three dot-separated numeric segments named "major",
   "minor" and "patch".
 
-By convention a **type** should be the same as the
-PURL **type** for a given package or software ecosystem. It is, however,
-allowed to define a **type** that does not match an existing PURL **type**
-such as a scheme that applies to a single package or project.
+By convention a **type** should be the same as the PURL **type** for a given
+package or software ecosystem. It is, however, allowed to define a **type**
+that does not match an existing PURL **type** such as a version scheme that
+applies to a single package or project or a general purpose version scheme
+like 'semver-2.0.0'.
 
-### constraints
+This Standard includes the VERS Definition Schema but it does not include the
+set of current "registered" VERS type (JSON format) definition files because
+there are ongoing additions and changes to these files. The set of current "registered" VERS type definition files are located at: https://www.packageurl.org/vers-types/. Registration refers to the Package-URL community process for
+adding a new VERS type.
+
+There are two rules related to the set of registered VERS type definitions for conforming tools to validate the VERS type component of a VERS notation:
+
+- If a VERS **type** is registered, then a VERS notation is invalid if it does
+  not conform to all of the rules for the corresponding VERS **type**
+  definition.
+- If a VERS **type** is not registered, then the **type** component is valid
+  if it conforms to the rules stated in the **type** component rules in this
+  Clause of the Standard. In this case a tool should report a warning that the
+  VERS type is not registered.
+
+### 5.3.3 Constraints
 - The **constraints** component shall be preceded by an unencoded
   '/' slash separator when not empty.
-- Each instance of the **constraints** component is composed of either
-  a single **version** as in '1.2.3' or the combination of a **comparator**
-  and a **version** as in '>=2.0.0'.
+- Each instance of the **constraints** component is called a **constraint**.
+  Each **constraint** is composed of either a single **version** as in
+  '1.2.3' or the combination of a **comparator** and a **version** as in
+  '>=2.0.0'.
 - A **comparator** always precedes the **version** with no characters allowed
   between the **comparator** and the **version**.
-- Multiple **constraints** strings shall be separated by an unencoded
+- Multiple **constraints** shall be separated by an unencoded
   pipe '|'. The pipe "|" has no special meaning other than being a separator.
 
-#### Comparator characters
+#### 5.3.1 Comparators
 A **comparator** is composed of these ASCII characters:
 - the Equals character: '=' (equals, '=')
 - the Not Equals character: '!' (exclamation mark, '!')
@@ -89,10 +104,6 @@ A **comparator** is composed of these ASCII characters:
 - the Asterisk character: '\*' (asterisk, '*')
 
 A **comparator** shall be one of the following:
-- '=' is the Equality **comparator**. This means that a version shall be equal
-  to the provided version. The Equality **comparator** shall only be used
-  implicitly. For example `vers:npm/1.2.3` means that the version is equal to
-  "1.2.3"
 - '!=' is the Inequality **comparator**. This means that a version shall not
   be equal to the provided version and it shall be excluded from the range.
   For example: '!=1.2.3' means that version   "1.2.3" is excluded.
@@ -111,29 +122,30 @@ A **comparator** shall be one of the following:
   by a version. For example, 'vers:deb/\*' represents all versions of a
   Debian package. This includes past, current and possible future versions.
 
-#### Version strings
+There is no Equality **comparator** (equals, '=') because a **version**
+without a **comparator** asserts equality. For example `vers:npm/1.2.3` means
+that the **version** is equal to "1.2.3". If a **constraint** string starts
+with '=', tools shall report an error.
+
+#### 5.3.2 Version**
 A **version** is an ASCII string.
 
-A single **version** in a **constraints** string means that a version
+A single **version** in a **constraint** string means that a version
 equal to this version satisfies the range specification. Equality is based on
 the equality of two normalised version strings according to the applicable
 **type**. For most schemes, this is a simple string equality. A
 **type** may, however, define normalisation and other rules for
 equality such as the "pypi" rules from PEP 440.
 
-The equality comparator shall be implicit only and represented by a single
-**version** without any leading comparator character. If a **constraints**
-string starts with '=', tools shall report an error.
-
 A package version satisfies a set of **constraints** if it is
 contained within any of the intervals defined by the **constraints**.
 
-## Version construction, parsing and validation rules
+## 5.4 VERS validation rules
 
-VERS construction and validation rules are designed such that a VERS is
-easy to read and understand by humans and straightforward to process
-with tools. The rules are designed to prevent the creation of empty or
-impossible version ranges.
+VERS validation rules are designed such that a VERS notation is easy for a
+human to read and understand, and straightforward for tools to process. The
+rules are also designed to prevent the creation of empty or impossible version
+ranges.
 
 - Tools shall report an error for an invalid VERS string.
 - A version range specifier contains only printable ASCII letters,
@@ -141,136 +153,46 @@ impossible version ranges.
 - ASCII whitespace is not permitted in a VERS string. Tools shall report an
   error if any Whitespace character, for example SPACE (0x20), TAB (0x09), or
   LF (0x0A), is used.
-- The VERS **scheme** and **type** are always lowercase as in
-  'vers:npm'.
+- The VERS **scheme** and **type** are always lowercase as in 'vers:npm'.
 - Versions are case-sensitive. A **type** may specify
-  its own case sensitivity.
-- If a version in a **constraints** string contains any of these characters:
+  case sensitivity for that **type**.
+- If a version in a **constraint** string contains any of these characters:
   '>', '<', '=', '!', '*', '|', '%', these characters shall be
   percent-encoded using URI percent-encoding rules.
 - Tools shall report an error for invalid percent-encoded sequences.
 
-The list of **constraints** strings for a range are like a set of
-signposts in the version timeline of a package. The separators do not mean
-"and" or "or". They are separators in a sequence of **constraints**.
+The list of **constraint** strings represent distinct intervals in the version
+timeline of a a package. The separators do not mean "and" or "or". They are
+separators in a sequence of **constraints**.
 
 With a few simple validation rules, we can avoid the creation of most empty or
 impossible version ranges. These rules are:
 
-- Constraints shall be sorted by version order. The ordering of
-  **constraints** components is significant for validity: tools shall report
+- **Constraints** shall be sorted by version order. The ordering of the
+  **constraint** instances is significant for validity: tools shall report
   an error for invalid ordering.
-- Versions are unique. Each version shall be unique in a range
-  and can occur only once in any **constraints** component of
-  VERS, regardless of the **comparators**. Tools shall report an
-  error for duplicated versions.
-- There can be only one asterisk: if used, '\*' shall occur only once and
-  alone in a range, without any other constraint or version.
+- Versions are unique. Each version shall be unique in a **constraints**
+  string and can occur only once in any **constraint**, regardless of the **comparators**. Tools shall report an error for duplicated versions.
+- There can be only one asterisk in a **constraints** string: '\*' shall occur
+  only once and alone in a **constraints** string.
 
-Starting from a de-duplicated and sorted list of constraints, these
-extra rules apply to the **comparators** of any two contiguous constraints:
+Starting from a de-duplicated and sorted list of **constraints**, the
+following rules apply to the **comparators** of any two contiguous
+**constraints**:
 
 - A constraint using the '!=' **comparator** can be followed by a constraint
   using any **comparator** (any of '=', '!=', '>', '>=', '<', '<=') or no
   constraint.
-
-Ignoring all constraints with the '!=' **comparator**:
-
-- A constraint using the '=' **comparator** shall be followed only by a
-  constraint with one of   '=', '>', or '>=' as the **comparator** or no
-  constraint.
-
-Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
-of constraints shall be an alternation of Greater-than and Lesser-than
-**comparators**:
+- Ignoring all **constraints** with the '!=' **comparator**, an equality
+  **constraint** shall be followed only by a **constraint** with
+  one of **comparators**: '=', '>', or '>=' or no **constraint**.
+- Ignoring all constraints with a '=' or '!=' **comparator**, the sequence
+  of **constraints** shall be an alternation of Greater-than and Lesser-than
+  **comparators**:
 - A constraint using '\<' and '\<=' shall be followed by one of '>' or '>='
   (or no constraint).
 - A constraint using '>' and '>=' shall be followed by one of '\<' or '\<='
   (or no constraint).
 
-Tools shall report an error for such invalid ranges.
+Tools shall report an error for an invalid sequence of **constraints**.
 
-### Using version range specifiers
-
-A primary VERS use case is to test if a version is within a range.
-A version is within a version range if it falls within any of the intervals
-defined by a range. Otherwise, the version is outside of the version
-range.
-
-Some important use cases derived from this include:
-
-- **Resolve a version range specifier to a list of specific versions.**
-
-  In this use case, the input is one or more known versions of
-  a package. Each version is then tested to check if it lies inside or
-  outside the range. For example, given a vulnerability and the VERS
-  describing the vulnerable versions of a package, this process is
-  used to determine if an existing package version is vulnerable.
-
-- **Select one of several versions that are within a range.**
-
-  In this use case, with the input of several versions that are within a
-  range and several packages that express package dependencies
-  qualified by a version range, a package management tool will
-  determine and select the set of package versions that satisfy
-  the version range constraints of all of the dependencies. This
-  usually requires deploying heuristics and algorithms (possibly
-  as complex as SAT solvers) that are ecosystem- and tool-specific
-  and outside of the scope of this specification. VERS could
-  be used in tandem with PURL to provide an input to this dependency
-  resolution process.
-
-### Examples
-
-For example, to define a set of versions that contains either version
-"1.2.3", or any versions greater than or equal to "2.0.0" but less than
-"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
-the version range specifier will be:
-
-    vers:npm/1.2.3|>=2.0.0|<5.0.0
-
-This is an example of how to read a set of **constraints** in version
-order from left to right to determine the versions that are included in a
-VERS notation. In this case you process in order:
-- Include a single version "1.2.3"
-- Include versions that are ">=2.0.0"
-- Stop including versions when you reach the constraint "<5.0.0"
-
-Other examples are:
-
-#### A single version in an "npm" package dependency:
-For a package dependency originally seen as a dependency on version "1.2.3" in
-a `package.json` manifest file the version range specification is:
-
-    vers:npm/1.2.3
-
-#### A list of versions, enumerated:
-    vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
-
-#### A complex statement about a vulnerability in a "maven" package:
-For a "maven" package vulnerability that affects multiple branches,
-each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
-Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
-Apache TomEE 1.0.0-beta1 - 1.7.5.`
-
-- A normalised VERS notation is:
-
-      vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
-
-- An alternative is to use four VERS notations to cover the same range using
-  one VERS for each of the vulnerable "branches":
-
-      vers:tomee/>=1.0.0-beta1|<=1.7.5
-      vers:tomee/>=7.0.0-M1|<=7.0.7
-      vers:tomee/>=7.1.0|<=7.1.2
-      vers:tomee/>=8.0.0-M1|<=8.0.1
-
-  See also: https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/
-
-#### Converting RubyGems custom syntax for dependencies:
-Note how the pessimistic version constraint is expanded for the RubyGems
-dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
-
-- The VERS notation is:
-
-      vers:gem/>=2.2.0|!=2.2.1|<2.3.0

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -131,21 +131,29 @@ without a **comparator** asserts equality. For example `vers:npm/1.2.3` means
 that the **version** is equal to "1.2.3". If a **constraint** string starts
 with '=', tools shall report an error.
 
-#### 5.3.3.2 Version**
+#### 5.3.3.2 Version
 A **version** is an ASCII string.
 - A **version** contains only printable ASCII letters, digits and punctuation.
-- ASCII whitespace is not permitted in a VERS string except for a
-  percent-encoded space (' '). Tools shall report an error if any other  whitespace character, for example tab or line feed, is used.
 - If a **version** contains any of these characters:
   '>', '<', '=', '!', '*', '|', '%', these characters shall be
   percent-encoded using URI percent-encoding rules.
+- ASCII whitespace is not permitted in a VERS string except for a
+  percent-encoded space (' '). Tools shall report an error if any other
+  ASCII whitespace character, for example tab or line feed, is used.
+  Percent-encoding is applied to the literal **version** data: a literal '%'
+  in a **version** shall be encoded as '%25', while the '%' that starts an
+  existing percent-encoded triplet shall not be encoded again.
 - Tools shall report an error for invalid percent-encoded sequences.
 
-A single **version** in a **constraint** means that a package version equal to this version satisfies the range specification. Equality is based on the
-equality of two normalised version strings according to the applicable **type**. For most schemes, this is a simple string equality. A **type** may, however,
-define normalisation or other rules for equality such as the "pypi" rules from PEP 440.
+A single **version** in a **constraint** means that a package version equal to
+this version satisfies the range specification. Equality is based on the
+equality of two normalised version strings according to the applicable
+**type**. For most schemes, this is a simple string equality. A **type** may,
+however, define normalisation or other rules for equality such as the "pypi"
+rules from PEP 440.
 
-A package version satisfies VERS **constraints** if it is contained within any of the segments defined by the **constraints**.
+A package version satisfies VERS **constraints** if it is contained within any
+of the segments defined by the **constraints**.
 
 ## 5.4 VERS validation rules
 
@@ -158,7 +166,8 @@ ranges. These rules are:
   **constraints** segments is significant for validity: tools shall report
   an error for invalid ordering.
 - **Versions** are unique. Each version shall be unique within a
-  **constraints** instance, and can occur only once in any **constraint**, regardless of the **comparators**. Tools shall report an error for
+  **constraints** instance, and can occur only once in any **constraint**,
+  regardless of the **comparators**. Tools shall report an error for
   duplicated **versions**.
 - There can be only one asterisk in a **constraints** instance: '\*' shall
   occur only once and alone in **constraints** instance.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -24,7 +24,7 @@ Some important use cases derived from this include:
   dependencies. This usually requires deploying heuristics and algorithms
   (possibly as complex as SAT solvers) that are ecosystem- and tool-specific
   and outside of the scope of this specification. VERS can be used in tandem
-  with PURL to provide an input to this dependency   resolution process.
+  with PURL to provide an input to this dependency resolution process.
 
 ## Examples
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,7 +1,7 @@
 # VERS use cases
 
 A primary VERS use case is to test if a package version is contained with a
-**constraints** string. A package version is within VERS **constraints** if it
+**constraints** sequence. A package version is within VERS **constraints** if it
 falls within any of the intervals defined by the **constraints**.  Otherwise,
 the package version is outside of the **constraints**.
 
@@ -31,13 +31,13 @@ Some important use cases derived from this include:
 For example, to define a set of versions that contains either version
 "1.2.3", or any versions greater than or equal to "2.0.0" but less than
 "5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
-the VERS notation will be:
+the VERS will be:
 
     vers:npm/1.2.3|>=2.0.0|<5.0.0
 
 This is an example of how to read a **constraints** string in version
 order from left to right to determine the versions that are included in a
-VERS notation. In this case you process in order:
+VERS. In this case you process in order:
 - Include a single version "1.2.3"
 - Include versions that are ">=2.0.0"
 - Stop including versions when you reach the constraint "<5.0.0"
@@ -46,7 +46,7 @@ Other examples are:
 
 ### A single version in an "npm" package dependency:
 For a package dependency originally seen as a dependency on version "1.2.3" in
-a `package.json` manifest file the VERS notation is:
+a `package.json` manifest file the VERS is:
 
     vers:npm/1.2.3
 
@@ -59,12 +59,12 @@ each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
 Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
 Apache TomEE 1.0.0-beta1 - 1.7.5.`
 
-- A normalised VERS notation is:
+- A normalised VERS is:
 
       vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
 
 - An alternative is to use four VERS notations to cover the same range using
-  one VERS notation for each of the vulnerable "branches":
+  one VERS for each of the vulnerable "branches":
 
       vers:tomee/>=1.0.0-beta1|<=1.7.5
       vers:tomee/>=7.0.0-M1|<=7.0.7
@@ -77,6 +77,6 @@ Apache TomEE 1.0.0-beta1 - 1.7.5.`
 Note how the pessimistic version **constraint** is expanded for the RubyGems
 dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
 
-- The VERS notation is:
+- The VERS is:
 
       vers:gem/>=2.2.0|!=2.2.1|<2.3.0

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,82 @@
+# VERS use cases
+
+A primary VERS use case is to test if a package version is contained with a
+**constraints** string. A package version is within VERS **constraints** if it
+falls within any of the intervals defined by the **constraints**.  Otherwise,
+the package version is outside of the **constraints**.
+
+Some important use cases derived from this include:
+
+- **Resolve a version range specifier to a list of specific versions.**
+
+  In this use case, the input is one or more known versions of
+  a package. Each version is then tested to check if it lies inside or
+  outside the **constraints**. For example, given a vulnerability and the VERS
+  describing the vulnerable versions of a package, this process is
+  used to determine if a specific package version is vulnerable.
+
+- **Select one of several versions that are within a range.**
+
+  In this use case, with the input of several package versions that are within
+  a range and several packages that express package dependencies qualified by
+  a version range, a package management tool will determine and select the set
+  of package versions that satisfy the **constraints** of all of the
+  dependencies. This usually requires deploying heuristics and algorithms
+  (possibly as complex as SAT solvers) that are ecosystem- and tool-specific
+  and outside of the scope of this specification. VERS can be used in tandem
+  with PURL to provide an input to this dependency   resolution process.
+
+## Examples
+
+For example, to define a set of versions that contains either version
+"1.2.3", or any versions greater than or equal to "2.0.0" but less than
+"5.0.0" using the "node-semver" version scheme for the "npm" PURL **type**,
+the VERS notation will be:
+
+    vers:npm/1.2.3|>=2.0.0|<5.0.0
+
+This is an example of how to read a **constraints** string in version
+order from left to right to determine the versions that are included in a
+VERS notation. In this case you process in order:
+- Include a single version "1.2.3"
+- Include versions that are ">=2.0.0"
+- Stop including versions when you reach the constraint "<5.0.0"
+
+Other examples are:
+
+### A single version in an "npm" package dependency:
+For a package dependency originally seen as a dependency on version "1.2.3" in
+a `package.json` manifest file the VERS notation is:
+
+    vers:npm/1.2.3
+
+### A list of versions, enumerated:
+    vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
+
+### A complex statement about a vulnerability in a "maven" package:
+For a Maven package vulnerability that affects multiple branches,
+each with its own fixed version: `affects Apache TomEE 8.0.0-M1 - 8.0.1,
+Apache TomEE 7.1.0 - 7.1.2, Apache TomEE 7.0.0-M1 - 7.0.7,
+Apache TomEE 1.0.0-beta1 - 1.7.5.`
+
+- A normalised VERS notation is:
+
+      vers:maven/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
+
+- An alternative is to use four VERS notations to cover the same range using
+  one VERS notation for each of the vulnerable "branches":
+
+      vers:tomee/>=1.0.0-beta1|<=1.7.5
+      vers:tomee/>=7.0.0-M1|<=7.0.7
+      vers:tomee/>=7.1.0|<=7.1.2
+      vers:tomee/>=8.0.0-M1|<=8.0.1
+
+  See also: https://repo1.maven.org/maven2/org/apache/tomee/apache-tomee/
+
+### Converting RubyGems custom syntax for dependencies:
+Note how the pessimistic version **constraint** is expanded for the RubyGems
+dependency expression: `'library', '~>2.2.0', '!=2.2.1', '<2.3.0'`
+
+- The VERS notation is:
+
+      vers:gem/>=2.2.0|!=2.2.1|<2.3.0


### PR DESCRIPTION
Edits to improve clarity of the Core VERS Spec including:
- Standardize use of **constraints** instead of version ranges when specifying VERS rules
- Added numbered headings 
- Moved the use cases and examples to a new separate document: docs/use-cases.md because sections are commentary not specification

There are (at least) two pending issues:
- Review the whitespace rules - do we really need to reference SPACE, TAB or LF in section 5.4?
- We decided to remove 'equality' as a **comparator** but this makes it difficult to clearly describe equality conditions in section 5.4