### PR TITLE
Clarify handling of empty constraint sets

### DIFF
--- a/docs/specification/how-to-parse.md
+++ b/docs/specification/how-to-parse.md
@@ -21,9 +21,9 @@ To parse a VERS string:
 - Split the specifier from left once on a slash '/'.
 - The left hand side is the **type** that shall be lowercase. Tools should
   validate that the **type** is a known **type**.
-- The right hand side is a list of one or more constraints. Tools
-  validate that this **constraints** string is not empty
-  after splitting.
+- The right hand side is a non-empty list of one or more **constraints**.
+  Tools shall report an error if this **constraints** string is empty after
+  splitting.
 - If the string is equal to '\*', the **constraints** value is
   '*'. Parsing is done and no further processing is needed for this VERS.
   A tool should report an error if there are characters other than '\*'.

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -85,7 +85,7 @@ There are two rules related to the set of registered VERS **type** definitions f
 
 ### 5.3.3 Constraints
 - The **constraints** component shall be preceded by an unencoded
-  '/' slash separator when not empty.
+  '/' slash separator and shall contain one or more **constraints**.
 - Each segment of the **constraints** component is called a **constraint**.
   Each **constraint** is composed of either a single **version** as in
   '1.2.3' or the combination of a **comparator** and a **version** as in

--- a/tests/vers_canonical_parse_test.json
+++ b/tests/vers_canonical_parse_test.json
@@ -29,6 +29,14 @@
       "expected_message": "non-canonical VERS: whitespace is not permitted"
     },
     {
+      "description": "Parsing fails when the constraints component is empty.",
+      "test_group": "required",
+      "test_type": "parse",
+      "input": "vers:npm/",
+      "expected_failure": true,
+      "expected_message": "non-canonical VERS: constraints must not be empty"
+    },
+    {
       "description": "Parsing fails when constraints start with a pipe.",
       "test_group": "required",
       "test_type": "parse",


### PR DESCRIPTION
This PR addresses #96. It clarifies that empty constraint sets are invalid:
- Adapted how-to-parse to clarify that an error should be reported in case of empty constraint sets
- Adapted Clause 5, clarifying the ambiguous statement which previously suggested that the constraints component could be empty
- Added a test