### PR TITLE
Clarify that pipe is not present in every VERS component

### DIFF
--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -3,7 +3,10 @@
 VERS stands for "Version Range Specifier". A VERS is an ASCII URI string
 composed of three components:
 
-    scheme:type/constraints|
+    scheme:type/constraints
+
+When there are multiple **constraints**, they are separated by an unencoded
+pipe '|'.
 
 Components are separated by a specific character for unambiguous parsing.
 

--- a/docs/specification/standard/specification.md
+++ b/docs/specification/standard/specification.md
@@ -10,7 +10,10 @@ hide_table_of_contents: false
 VERS stands for "VErsion Range Specifier. A VERS is an ASCII URI string composed of
 three components:
 
-    scheme:type/constraints|
+    scheme:type/constraints
+
+When there are multiple **constraints**, they are separated by an unencoded
+pipe '|'.
 
 Components are separated by a specific character for unambiguous parsing.
 


### PR DESCRIPTION
This PR makes a minor clarification to the VERS component notation. The previous notation could be misread as a kind of regular expression that requires a trailing pipe (|) after the constraints. The notation now makes clear that pipes are used only to separate multiple constraints.

