### PR TITLE
Add gem definition

### DIFF
--- a/types/gem-definition.json
+++ b/types/gem-definition.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://packageurl.org/schemas/vers-type-definition.schema-0.2.json",
+  "$id": "https://packageurl.org/vers-types/gem-definition.json",
+  "type": "gem",
+  "type_name": "gem versioning",
+  "description": "gem versioning version ranges. Versions are evaluated with the `Gem::Version`",
+  "vers_examples": [
+    "vers:gem/>=1.2.0|<1.2.0.1",
+    "vers:gem/>=1.1.0.1|<=2.1.0",
+    "vers:gem/>=0.0.2.beta|<0.0.3",
+    "vers:gem/<1.4.1.beta|>=2.0|<2.17.2.1",
+    "vers:gem/<1.4.1.gamma|>=2.0.0|<2.17.2",
+    "vers:gem/>=2.0.0.pre.alpha8|<=2.0.0.rc2|>=2.0.0|<=2.13.0.1",
+    "vers:gem/>=2.2.6|<2.47.0|>2.51.0|<=2.67.0",
+    "vers:gem/>=1.7.0|<1.7.16|>=1.8.0|<1.8.8|>=2.0.0|<2.0.8|>=3.0.0.pre.beta.1|<3.0.0.pre.beta.7"
+  ],
+  "native_range_and_vers_equivalent_examples": [
+    {
+      "native_range": "~>1.1.7, >= 2.0.1",
+      "vers": "vers:gem/>=1.1.7|<2.0.0|>=2.0.1"
+    },
+    {
+      "native_range": "~>1.6.5, >=1.7.2",
+      "vers": "vers:gem/>=1.6.5|<1.7.0|>=1.7.2"
+    },
+    {
+      "native_range": "",
+      "vers": "vers:gem/*"
+    },
+    {
+      "native_range": "2.1.4",
+      "vers": "vers:gem/2.1.4"
+    },
+    {
+      "native_range": ">=2.0.0 <=4.0.4",
+      "vers": "vers:gem/>=2.0.0|<=4.0.4"
+    },
+    {
+      "native_range": "~> 2.0",
+      "vers": "vers:gem/>=2.0|<3.0"
+    },
+    {
+      "native_range": "~> 3.5.0",
+      "vers": "vers:gem/>=3.5.0|<3.6"
+    },
+  ],
+  "reference_urls": [
+    "https://guides.rubygems.org/versioning/",
+    "https://guides.rubygems.org/dependency-resolution/",
+    "https://ruby-doc.org/stdlib-2.5.0/libdoc/rubygems/rdoc/Gem/Version.html"
+  ]
+}


### PR DESCRIPTION
Taking a crack at adding a rubygems `gem` type definition. The references I used are listed in the json itself, but a few discussion points to call out directly https://guides.rubygems.org/versioning/
Mentions `semver` directly and a casual read of the page could leave someone thinking that rubygems uses the semver spec. They do not. If you read the section `How RubyGems compares versions` they state that they use `Gem::Version` to handle versions. The docs for that gem are here https://ruby-doc.org/stdlib-2.5.0/libdoc/rubygems/rdoc/Gem/Version.html and (imo) are not the most amazing docs I've read. Some behavior to be aware of
`*` is not a valid character 
ex.
```
jon@Eddie ~/g/!/cve-publication-tool (main)> irb
irb(main):001:0> ver = Gem::Version
=> Gem::Version
irb(main):002:0> ver.create('*')
Traceback (most recent call last):
        8: from /usr/bin/irb:23:in `<main>'
        7: from /usr/bin/irb:23:in `load'
        6: from /Library/Ruby/Gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        5: from (irb):2
        4: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/version.rb:194:in `create'
        3: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/version.rb:203:in `new'
        2: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/version.rb:203:in `new'
        1: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/version.rb:212:in `initialize'
ArgumentError (Malformed version number string *)
irb(main):003:0> ver.create('')
=> #<Gem::Version "0">
```
`-` gets transmuted
```
irb(main):005:0> ver.create('1.2.3.4.5.6.7.8-alpha')
=> #<Gem::Version "1.2.3.4.5.6.7.8.pre.alpha">
```
the number of `.`s is also arbitrary (as much as I've tested at least).

ordering is tolerant of mismatched lengths
```
irb(main):010:0> puts %w[2.0.0 2.0.0.7 1.0.1 1.0.0.rc1 1.0.0.rho1 1.0.0.beta2 1.1.0-beta 1.0.0.alpha].map { |v| Gem::Version.new(v) }.sort
1.0.0.alpha
1.0.0.beta2
1.0.0.rc1
1.0.0.rho1
1.0.1
1.1.0.pre.beta
2.0.0
2.0.0.7
```
I think ordering can largely be ignored for the purposes of vers, but wanted to call it out for the sake of completeness.

One test I want to call out directly and get opinions on is
```
{
  "native_range": "",
  "vers": "vers:gem/*"
},
```
which is not how the version gem renders an empty string
```
irb(main):011:0> ver.create('')
=> #<Gem::Version "0">
```
But is often how rubygems developers tend to allow for a floating requirement (at least as best as I understand) ex.
https://github.com/mastodon/mastodon/blob/0a32b4a831838ef1f363a915c2e71e2a1b52cf0d/Gemfile#L7

So, not 100% sure which way `vers` should go on this one.