### PR TITLE
Update $id for new VERS schemas to vers-schema

### DIFF
--- a/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
+++ b/docs/specification/standard/Clause-6-VERS-Type-Definition-Schema.md
@@ -14,7 +14,7 @@ The VERS Type Definition Schema is formally specified by a Draft 2020-12 JSON
 Schema. Each published version of this specification is accompanied by a
 versioned meta-schema at a stable URI:
 
-https://packageurl.org/schemas/vers-type-definition.schema-<major>.<minor>.json
+https://packageurl.org/vers-schemas/vers-type-definition.schema-<major>.<minor>.json
 
 **Location:** /
 

--- a/schemas/vers-test.schema-0.2.json
+++ b/schemas/vers-test.schema-0.2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema#",
-  "$id": "https://packageurl.org/schemas/vers-test.schema-0.2.json",
+  "$id": "https://packageurl.org/vers-schemas/vers-test.schema-0.2.json",
   "title": "VERS test definition",
   "description": "Schema for Version Range Specifier (VERS) test case definitions.",
   "type": "object",

--- a/schemas/vers-type-definition.schema-0.2.json
+++ b/schemas/vers-type-definition.schema-0.2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema#",
-  "$id": "https://packageurl.org/schemas/vers-type-definition.schema-0.2.json",
+  "$id": "https://packageurl.org/vers-schemas/vers-type-definition.schema-0.2.json",
   "title": "VErsion Range Specifier (VERS) Type Definition",
   "description": "Schema to define the structure of a VErsion Range Specifier (VERS) type.",
   "type": "object",

--- a/schemas/vers-types-index.schema-0.1.json
+++ b/schemas/vers-types-index.schema-0.1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
-  "$id": "https://packageurl.org/schemas/vers-type-index.schema-0.1.json",
+  "$id": "https://packageurl.org/vers-schemas/vers-type-index.schema-0.1.json",
   "title": "VErsion Range Specifier (VERS) types index",
   "description": "An index of registered VERS types.",
   "type": "array",


### PR DESCRIPTION
Update the $id location of the VERS schema files for the 3 schemas that will be part of the ECMA-VERS release 
from: https://packageurl.org/schemas/
to: https://packageurl.org/vers-schemas/

No change to: `vers-test.schema-0.1.json` because it has been superseded by v0.2. We will keep a copy at its current location:
https://packageurl.org/schemas/vers-test.schema-0.1.json
Also no change to: `vers-type-definition.schema-0.1.json` because this has never been used and will be deleted after we finalize
`vers-type-definition.schema-1.0..json`