### PR TITLE
Fix typos, add missing constraints pairs

### DIFF
--- a/docs/specification/how-to-parse.md
+++ b/docs/specification/how-to-parse.md
@@ -15,7 +15,7 @@ are:
 - **type** and **constraints** are standard VERS components
 - **constraint**: refers to one instance of a constraint within a sequence of
   constraints (the **constraints** component)
-- Each **constraint" is composed of a **comparator** and a
+- Each **constraint** is composed of a **comparator** and a
   **version**
 - **comparator**: a set of characters defined in Clause 5
 - **version**: the version string within a single **constraint**
@@ -96,6 +96,7 @@ These pairs of contiguous **constraint** strings with these **comparators**
 are valid:
 
 - '!=' followed by anything
+- 'null' followed by '>', '>='
 - '<', or '<=' followed by '!=', '>', '>=' or null
 - '>', or '>=' followed by '!=', '<', or '<='
 

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -184,7 +184,7 @@ following rules apply to the **comparators** of any two contiguous
 - Ignoring all **constraints** with the '!=' **comparator**, an equality
   **constraint** shall be followed only by a **constraint** with one of the **comparator** characters: '>', or '>=', or no **comparator** (for equality)
   or no **constraint**.
-- Ignoring all constraints with no **comparator (equality) or the '!='
+- Ignoring all constraints with no **comparator** (equality) or the '!='
   **comparator**, the sequence of **constraints** shall be an alternation of Greater-than and Lesser-than **comparators**:
 - A **constraint** using '\<' or '\<=' shall be followed by one of '>' or
   '>=' (or no **constraint**).


### PR DESCRIPTION
This PR proposed two small improvements to the how-to-parse guide:
- Fix two typos
- Add two missing cases of allowed constraint pairs