### PR TITLE
Updated equality comparator definition

### DIFF
--- a/docs/specification/how-to-parse.md
+++ b/docs/specification/how-to-parse.md
@@ -91,7 +91,7 @@ These pairs of contiguous **constraint** strings with these **comparators**
 are valid:
 
 - '!=' followed by anything
-- *null* followed by '>', '>='
+- *null* followed by *null*, '!=', '>', '>='
 - '<', or '<=' followed by '!=', '>', '>=' or *null*
 - '>', or '>=' followed by '!=', '<', or '<='
 

--- a/docs/specification/how-to-parse.md
+++ b/docs/specification/how-to-parse.md
@@ -49,33 +49,28 @@ are:
   **constraint** strings. Tools shall report an error if consecutive
   pipes ('|') are present.
 - For each **constraint** string determine:
-    - If the **constraint** string starts with no **comparator** value then
-      this is the implicit equality condition and the remaining string is the
-      **version**. For the following steps related to parsing or validating
-      **comparator** values this implicit equality condition is referenced as
-      null.
+    - If it starts with '>=', then the **comparator** is '>='.
+    - If it starts with '<=', then the **comparator** is '<='.
+    - If it starts with '!=', then the **comparator** is '!='.
+    - If it starts with '<', then the **comparator** is '<'.
+    - If it starts with '>', then the **comparator** is '>'.
+    - If it does not start with one of the **comparators** listed above, then
+      the **comparator** is the default Equality **comparator** (*null*) and
+      the next character in the **constraint** string is the first character
+      of the **version**.
     - If the **constraint** string starts with '=', tools shall
       report an error: the equality condition is implicit and shall be
       represented by a bare version without a leading '='.
-   -  If the **constraint** string starts with one of the two-character
-      **comparator** values ('>=', '<=', '!=') or with one of the
-      one-character **comparator** values ('<', '>') and:
-        - If it starts with '>=', then the **comparator** is '>='.
-        - If it starts with '<=', then the **comparator** is '<='.
-        - If it starts with '!=', then the **comparator** is '!='.
-        - If it starts with '<', then the **comparator** is '<'.
-        - If it starts with '>', then the **comparator** is '>'.
-      Remove the **comparator** from the beginning of a **constraint** string.
-      The remaining string is the **version**.
-    - Tools shall validate and report an error if the **version** is
-      empty.
-    - If the **version** contains a percent '%' character, tools shall
-      validate that each '%' starts a valid percent-encoded triplet.
-    - Tools shall apply percent-decoding exactly once to the **version**
-      string.
-      Tools shall report an error for invalid percent-encoded sequences.
-    - Append the parsed **constraint** strings to the **constraints**
-      component.
+- Remove the **comparator** from the beginning of a **constraint** string.
+  The remaining string is the **version**.
+- Tools shall validate and report an error if the **version** is
+  empty.
+- If the **version** contains a percent '%' character, tools shall
+  validate that each '%' starts a valid percent-encoded triplet.
+- Tools shall apply percent-decoding exactly once to the **version**
+  string. Tools shall report an error for invalid percent-encoded sequences.
+- Append the parsed **constraint** strings to the **constraints**
+  component.
 - The results are the **type** and the **constraints** components.
 
 Tools shall validate and simplify **constraints** after parsing is complete
@@ -96,17 +91,17 @@ These pairs of contiguous **constraint** strings with these **comparators**
 are valid:
 
 - '!=' followed by anything
-- 'null' followed by '>', '>='
-- '<', or '<=' followed by '!=', '>', '>=' or null
+- *null* followed by '>', '>='
+- '<', or '<=' followed by '!=', '>', '>=' or *null*
 - '>', or '>=' followed by '!=', '<', or '<='
 
 The following pairs of contiguous **constraints** with these **comparators**
 are redundant and invalid (ignoring any instances of '!=' because this
 **comparator** can appear anywhere):
 
-- null, '<' or '<=' followed by '<' or '<=:'
+- *null*, '<' or '<=' followed by '<' or '<=:'
   this is the same as '<' or '<='
-- '>' or '>=' followed by null, '>' or '>=:'
+- '>' or '>=' followed by *null*, '>' or '>=:'
   this is the same as '>' or '>='
 
 A procedure to remove redundant **constraints** is:
@@ -133,15 +128,15 @@ A procedure to remove redundant **constraints** is:
 
     - If the current **comparator** is '>' or '>=' and the next **comparator**
       is '>' or '>=', discard the next **constraint**.
-    - If the current **comparator** is null, '<' or '<=' and
+    - If the current **comparator** is *null*, '<' or '<=' and
       the next **comparator** is '<' or '<=', discard the current
       **constraint**. The previous **constraint** becomes the current
       **constraint** if it exists.
     - If there is a previous **constraint** and:
          - If the previous **comparator** is '>' or '>=' and the current
-          **comparator** is null, '>' or '>=', discard the
+          **comparator** is *null*, '>' or '>=', discard the
           current **constraint**.
-        - If the previous **comparator** is null, '<' or '<='
+        - If the previous **comparator** is *null*, '<' or '<='
           and the current **comparator** is '<' or '<=', discard the previous
           **constraint**.
 
@@ -169,7 +164,7 @@ To check if a "tested version" is contained within a version range:
   performed below.
 
 - If the "tested version" is equal to any of the **constraint**
-  **versions** where the **comparator** is for equality (any of null,
+  **versions** where the **comparator** is for equality (any of *null*,
   '<=', or '>=') then the "tested version" is IN the range. The version check
   is finished.
 
@@ -179,8 +174,8 @@ To check if a "tested version" is contained within a version range:
 
 - Split the **constraints** component into two sub lists:
 
-    - a first list where the **comparator** is null or '!='
-    - a second list where the **comparator** is neither null nor '!='
+    - a first list where the **comparator** is *null* or '!='
+    - a second list where the **comparator** is neither *null* nor '!='
 
 - Iterate over the current and next contiguous **constraint** pairs (aka.
   pairwise) in the second list.

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -177,7 +177,8 @@ ranges. These rules are:
   duplicated **versions**.
 - There can be only one asterisk in a **constraints** sequence: Asterisk
   ('\*') shall occur only once and alone in a **constraints** instance.
-  An Asterisk constraint shall not be use with other **constraints** in a **constraints** sequence.
+  An Asterisk constraint shall not be use with other **constraints** in a
+  **constraints** sequence.
 
 Starting from a de-duplicated and sorted list of **constraints**, the
 following rules apply to the **comparators** of any two contiguous

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -72,11 +72,11 @@ applies to a single package or project or a general purpose version scheme
 like 'semver'.
 
 This Standard includes the *VERS Type Definition Schema* but it does not
-include the set of current "registered" VERS type definition files (in JSON
+include the set of current "registered" VERS type definition files (JSON
 format) because there are ongoing additions and changes to these files. The
-current "registered" VERS **type** definition files are located at: https://www.packageurl.org/vers-types/.
-Registration refers to the Package-URL community process for adding a new VERS
- **type**.
+current "registered" VERS **type** definition files are located at:
+https://www.packageurl.org/vers-types/. Registration refers to the Package-URL
+community process for adding a new VERS **type**.
 
 There are two rules related to the set of registered VERS **type** definitions
 for conforming tools to validate the VERS **type** component:
@@ -115,6 +115,9 @@ A **comparator** is composed of these ASCII characters:
 - the Asterisk character: '\*' (asterisk, '*')
 
 A **comparator** shall be one of the following:
+- *null* is the Equality **comparator** and the default. For example,
+  'vers:npm/1.2.3` means that the **version** is equal to "1.2.3". If a
+  **constraint** string starts with '=', tools shall report an error.
 - '!=' is the Inequality **comparator**. This means that a version shall not
   be equal to the provided version and it shall be excluded from the range.
   For example: '!=1.2.3' means that version "1.2.3" is excluded.
@@ -134,11 +137,6 @@ A **comparator** shall be one of the following:
   versions of a Debian package. This includes past, current and possible
   future versions.
 
-There is no Equality **comparator** (equals, '=') because a **version**
-without a **comparator** asserts equality. For example `vers:npm/1.2.3` means
-that the **version** is equal to "1.2.3". If a **constraint** string starts
-with '=', tools shall report an error.
-
 #### 5.3.3.2 Version
 A **version** is an ASCII string.
 - A **version** contains only printable ASCII letters, digits and punctuation.
@@ -155,7 +153,7 @@ A **version** is an ASCII string.
 
 A single **version** in a **constraint** means that a package version equal to
 this version satisfies the range specification. Equality is based on the
-equality of two normalised version strings according to the applicable
+equality of two normalised version strings according to the applicable VERS
 **type**. For most schemes, this is a simple string equality. A **type** may,
 however, define normalisation or other rules for equality such as the "pypi"
 rules from PEP 440.
@@ -177,23 +175,22 @@ ranges. These rules are:
   **constraints** instance, and can occur only once in any **constraint**,
   regardless of the **comparators**. Tools shall report an error for
   duplicated **versions**.
-- There can be only one asterisk in a **constraints** instance: '\*' shall
-  occur only once and alone in **constraints** instance.
+- There can be only one asterisk in a **constraints** instance: Asterisk
+  ('\*') shall occur only once and alone in a **constraints** instance.
 
 Starting from a de-duplicated and sorted list of **constraints**, the
 following rules apply to the **comparators** of any two contiguous
 **constraints** segments:
 
 - A **constraint** using the '!=' **comparator** can be followed by a
-  **constraint** using a **comparator** (any of '!=', '>', '>=', '<', '<=') or
-  no **constraint**.
-- Ignoring all **constraints** with the '!=' **comparator**, an equality
-  **constraint** shall be followed only by a **constraint** with one of the
-  **comparator** characters: '>', or '>=', or no **comparator** (for equality)
-  or no **constraint**.
-- Ignoring all constraints with no **comparator** (equality) or the '!='
-  **comparator**, the sequence of **constraints** shall be an alternation of
-  Greater-than and Lesser-than **comparators**:
+  **constraint** using a **comparator** (any of *null*, '!=', '>', '>=', '<',
+  '<=') or (no **constraint**).
+- Ignoring all **constraints** with the '!=' **comparator** or a **null*
+  (equality) **constraint** shall be followed only by a **constraint** with one
+  of: *null*, '>', or '>=' (or no **constraint**).
+- Ignoring all constraints with the '!=' **comparator** or the *null*
+  (equality) **comparator**, the sequence of **constraints** shall be an
+  alternation of Greater-than and Lesser-than **comparators**:
 - A **constraint** using '\<' or '\<=' shall be followed by one of '>' or
   '>=' (or no **constraint**).
 - A **constraint** using '>' or '>=' shall be followed by one of '\<' or

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -187,7 +187,7 @@ following rules apply to the **comparators** of any two contiguous
 - A **constraint** using the '!=' **comparator** can be followed by a
   **constraint** using a **comparator** (any of *null*, '!=', '>', '>=', '<',
   '<=') or (no **constraint**).
-- Ignoring all **constraints** with the '!=' **comparator**, a **null*
+- Ignoring all **constraints** with the '!=' **comparator**, a *null*
   (equality) **constraint** shall be followed only by a **constraint** with one
   of: *null*, '>', or '>=' (or no **constraint**).
 - Ignoring all constraints with the '!=' **comparator** or the *null*

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -175,8 +175,9 @@ ranges. These rules are:
   **constraints** instance, and can occur only once in any **constraint**,
   regardless of the **comparators**. Tools shall report an error for
   duplicated **versions**.
-- There can be only one asterisk in a **constraints** instance: Asterisk
+- There can be only one asterisk in a **constraints** sequence: Asterisk
   ('\*') shall occur only once and alone in a **constraints** instance.
+  An Asterisk constraint shall not be use with other **constraints** in a **constraints** sequence.
 
 Starting from a de-duplicated and sorted list of **constraints**, the
 following rules apply to the **comparators** of any two contiguous

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -186,7 +186,7 @@ following rules apply to the **comparators** of any two contiguous
 - A **constraint** using the '!=' **comparator** can be followed by a
   **constraint** using a **comparator** (any of *null*, '!=', '>', '>=', '<',
   '<=') or (no **constraint**).
-- Ignoring all **constraints** with the '!=' **comparator** or a **null*
+- Ignoring all **constraints** with the '!=' **comparator**, a **null*
   (equality) **constraint** shall be followed only by a **constraint** with one
   of: *null*, '>', or '>=' (or no **constraint**).
 - Ignoring all constraints with the '!=' **comparator** or the *null*

--- a/docs/specification/standard/Clause-5-VERS-Specification.md
+++ b/docs/specification/standard/Clause-5-VERS-Specification.md
@@ -195,7 +195,10 @@ following rules apply to the **comparators** of any two contiguous
 - A **constraint** using '\<' or '\<=' shall be followed by one of '>' or
   '>=' (or no **constraint**).
 - A **constraint** using '>' or '>=' shall be followed by one of '\<' or
-  '\<=' (or no **constraint**).
+  - A **constraint** using '\<' or '\<=' shall be followed by one of '>' or
+    '>=' (or no **constraint**).
+  - A **constraint** using '>' or '>=' shall be followed by one of '\<' or
+    '\<=' (or no **constraint**).
 
 Tools shall report an error for an invalid sequence of **constraints**
 segments.


### PR DESCRIPTION
This is an update to clarify the equality "comparator" items 
- Updated the equality **comparator** terminology to show the value as *null* 
- Simplified the Parsing VERS in how-to-parse.md